### PR TITLE
fix(bsky): add rev column to record table

### DIFF
--- a/packages/bsky/package.json
+++ b/packages/bsky/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atproto/bsky",
-  "version": "0.0.214",
+  "version": "0.0.215",
   "license": "MIT",
   "description": "Reference implementation of app.bsky App View (Bluesky API)",
   "keywords": [

--- a/packages/bsky/src/data-plane/server/db/migrations/20260615T140404000Z-add-record-rev.ts
+++ b/packages/bsky/src/data-plane/server/db/migrations/20260615T140404000Z-add-record-rev.ts
@@ -1,0 +1,16 @@
+import { Kysely, sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // Repo commit rev: read by the appview, written by wintermute to guard stale writes.
+  await sql`
+    ALTER TABLE record
+    ADD COLUMN IF NOT EXISTS "rev" varchar
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE record
+    DROP COLUMN IF EXISTS "rev"
+  `.execute(db)
+}

--- a/packages/bsky/src/data-plane/server/db/migrations/index.ts
+++ b/packages/bsky/src/data-plane/server/db/migrations/index.ts
@@ -59,3 +59,4 @@ export * as _20251120T004738098Z from './20251120T004738098Z-update-actor-age-as
 export * as _20260112T133951271Z from './20260112T133951271Z-add-drafts'
 export * as _20260202T120000000Z from './20260202T120000000Z-add-community-post'
 export * as _20260428T130000000Z from './20260428T130000000Z-add-actor-handle-resolve-tries'
+export * as _20260615T140404000Z from './20260615T140404000Z-add-record-rev'

--- a/packages/bsky/src/data-plane/server/db/tables/record.ts
+++ b/packages/bsky/src/data-plane/server/db/tables/record.ts
@@ -5,6 +5,7 @@ export interface Record {
   cid: string
   did: string
   json: string
+  rev: ColumnType<string | null, string | null | undefined, string | null>
   indexedAt: string
   takedownRef: string | null
   tags: ColumnType<string[] | null, string | undefined, string> | null


### PR DESCRIPTION
The appview reads `record.rev` (`hydration/actor.ts`, `data-plane/server/routes/records.ts`) and wintermute writes it for stale-write guarding, but neither the `record` table type nor any migration created the column — a fresh `migrateToLatestOrThrow` produced a `record` table without `rev`. Adds it to the table type (insert-optional, nullable) and a migration (`ADD COLUMN IF NOT EXISTS "rev" varchar`, metadata-only on PG 11+).

Bumps `@atproto/bsky` 0.0.214 → 0.0.215.

Test plan:
- [x] `tsc --build` typechecks clean (record insert in `processor.ts` still compiles — rev is insert-optional)