### PR TITLE
feat(bsky): add community video embed with 5gb size allowance

### DIFF
--- a/lexicons/community/blacksky/embed/video.json
+++ b/lexicons/community/blacksky/embed/video.json
@@ -1,0 +1,54 @@
+{
+  "lexicon": 1,
+  "id": "community.blacksky.embed.video",
+  "description": "A video embedded in a Blacksky community post. Mirrors app.bsky.embed.video with a larger size allowance.",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": ["video"],
+      "properties": {
+        "video": {
+          "type": "blob",
+          "description": "The mp4 video file. May be up to 5gb.",
+          "accept": ["video/mp4"],
+          "maxSize": 5000000000
+        },
+        "captions": {
+          "type": "array",
+          "items": { "type": "ref", "ref": "#caption" },
+          "maxLength": 20
+        },
+        "alt": {
+          "type": "string",
+          "description": "Alt text description of the video, for accessibility.",
+          "maxGraphemes": 1000,
+          "maxLength": 10000
+        },
+        "aspectRatio": {
+          "type": "ref",
+          "ref": "app.bsky.embed.defs#aspectRatio"
+        },
+        "presentation": {
+          "type": "string",
+          "description": "A hint to the client about how to present the video.",
+          "knownValues": ["default", "gif"]
+        }
+      }
+    },
+    "caption": {
+      "type": "object",
+      "required": ["lang", "file"],
+      "properties": {
+        "lang": {
+          "type": "string",
+          "format": "language"
+        },
+        "file": {
+          "type": "blob",
+          "accept": ["text/vtt"],
+          "maxSize": 20000
+        }
+      }
+    }
+  }
+}

--- a/lexicons/community/blacksky/feed/post.json
+++ b/lexicons/community/blacksky/feed/post.json
@@ -25,6 +25,7 @@
             "refs": [
               "app.bsky.embed.images",
               "app.bsky.embed.video",
+              "community.blacksky.embed.video",
               "app.bsky.embed.gallery",
               "app.bsky.embed.external",
               "app.bsky.embed.record",

--- a/lexicons/community/blacksky/feed/submitPost.json
+++ b/lexicons/community/blacksky/feed/submitPost.json
@@ -42,6 +42,7 @@
               "refs": [
                 "app.bsky.embed.images",
                 "app.bsky.embed.video",
+                "community.blacksky.embed.video",
                 "app.bsky.embed.external",
                 "app.bsky.embed.record",
                 "app.bsky.embed.recordWithMedia"

--- a/packages/bsky/src/api/community/blacksky/views/communityPostView.ts
+++ b/packages/bsky/src/api/community/blacksky/views/communityPostView.ts
@@ -112,7 +112,11 @@ export function buildCommunityEmbedView(
         .filter(Boolean),
     }
   }
-  if (e.$type === 'app.bsky.embed.video' && e.video) {
+  if (
+    (e.$type === 'app.bsky.embed.video' ||
+      e.$type === 'community.blacksky.embed.video') &&
+    e.video
+  ) {
     const cid = extractBlobCidString(e.video.ref)
     if (!cid) return undefined
     return {

--- a/packages/bsky/src/views/index.ts
+++ b/packages/bsky/src/views/index.ts
@@ -58,6 +58,7 @@ import {
   ActivitySubscription,
   BlockedPost,
   BookmarkView,
+  CommunityVideoEmbed,
   Embed,
   EmbedView,
   ExternalEmbed,
@@ -119,6 +120,7 @@ import {
   VerificationView,
   VideoEmbed,
   VideoEmbedView,
+  isCommunityVideoEmbedType,
   isExternalEmbedType,
   isGalleryEmbedType,
   isGalleryImageEmbedType,
@@ -2094,7 +2096,7 @@ export class Views {
   ): $Typed<EmbedView> | undefined {
     if (isImagesEmbedType(embed)) {
       return this.imagesEmbed(creatorFromUri(postUri), embed)
-    } else if (isVideoEmbedType(embed)) {
+    } else if (isVideoEmbedType(embed) || isCommunityVideoEmbedType(embed)) {
       return this.videoEmbed(creatorFromUri(postUri), embed)
     } else if (isGalleryEmbedType(embed)) {
       return this.galleryEmbed(creatorFromUri(postUri), embed)
@@ -2129,7 +2131,10 @@ export class Views {
     })
   }
 
-  videoEmbed(did: DidString, embed: VideoEmbed): $Typed<VideoEmbedView> {
+  videoEmbed(
+    did: DidString,
+    embed: VideoEmbed | CommunityVideoEmbed,
+  ): $Typed<VideoEmbedView> {
     const cid = getBlobCidString(embed.video)
     return app.bsky.embed.video.view.$build({
       cid,

--- a/packages/bsky/src/views/types.ts
+++ b/packages/bsky/src/views/types.ts
@@ -1,4 +1,4 @@
-import { app, chat, com, site } from '../lexicons/index.js'
+import { app, chat, com, community, site } from '../lexicons/index.js'
 
 // app.bsky.actor
 
@@ -33,6 +33,12 @@ export const isVideoEmbedType = app.bsky.embed.video.$isTypeOf
 export type VideoEmbed = app.bsky.embed.video.Main
 export type VideoEmbedView = app.bsky.embed.video.View
 
+// community.blacksky.embed.video mirrors app.bsky.embed.video and hydrates
+// to the same app.bsky.embed.video#view.
+export const isCommunityVideoEmbedType =
+  community.blacksky.embed.video.$isTypeOf
+export type CommunityVideoEmbed = community.blacksky.embed.video.Main
+
 export const isGalleryEmbedType = app.bsky.embed.gallery.$isTypeOf
 export type GalleryEmbed = app.bsky.embed.gallery.Main
 export type GalleryEmbedView = app.bsky.embed.gallery.View
@@ -64,6 +70,7 @@ export type RecordWithMediaEmbedView = app.bsky.embed.recordWithMedia.View
 export type Embed =
   | ImagesEmbed
   | VideoEmbed
+  | CommunityVideoEmbed
   | GalleryEmbed
   | ExternalEmbed
   | RecordEmbed


### PR DESCRIPTION
Adds `community.blacksky.embed.video` (mirrors `app.bsky.embed.video`, maxSize 5GB) to the submitPost and community post record embed unions, hydrating to the standard `app.bsky.embed.video#view`. We can't lift the 100MB cap on `app.bsky.embed.video` itself since bsky.app owns that lexicon.