### PR TITLE
feat(bsky): merge community posts into getTimeline and getAuthorFeed for members

### DIFF
--- a/packages/bsky/proto/bsky.proto
+++ b/packages/bsky/proto/bsky.proto
@@ -999,6 +999,7 @@ message GetAuthorFeedRequest {
   int32 limit = 2;
   string cursor = 3;
   FeedType feed_type = 4;
+  bool include_community_posts = 5;
 }
 
 message AuthorFeedItem {
@@ -1018,6 +1019,9 @@ message AuthorFeedItem {
 message GetAuthorFeedResponse {
   repeated AuthorFeedItem items = 1;
   string cursor = 2;
+  // Full rows for any community posts referenced in items, so the
+  // caller can build views without refetching.
+  repeated CommunityPostView community_posts = 3;
 }
 
 // - Returns recent posts authored by users followed by a given DID, paginated
@@ -1029,11 +1033,15 @@ message GetTimelineRequest {
   bool exclude_replies = 4;
   bool exclude_reposts = 5;
   bool exclude_quotes = 6;
+  bool include_community_posts = 7;
 }
 
 message GetTimelineResponse {
   repeated TimelineFeedItem items = 1;
   string cursor = 2;
+  // Full rows for any community posts referenced in items, so the
+  // caller can build views without refetching.
+  repeated CommunityPostView community_posts = 3;
 }
 
 message TimelineFeedItem {
@@ -1785,6 +1793,7 @@ service Service {
   // Community
   rpc CheckCommunityMembership(CheckCommunityMembershipRequest) returns (CheckCommunityMembershipResponse);
   rpc GetCommunityPost(GetCommunityPostRequest) returns (GetCommunityPostResponse);
+  rpc GetCommunityPosts(GetCommunityPostsRequest) returns (GetCommunityPostsResponse);
   rpc GetCommunityFeedByActor(GetCommunityFeedByActorRequest) returns (GetCommunityFeedByActorResponse);
   rpc SubmitCommunityPost(SubmitCommunityPostRequest) returns (SubmitCommunityPostResponse);
   rpc DeleteCommunityPost(DeleteCommunityPostRequest) returns (DeleteCommunityPostResponse);
@@ -1970,6 +1979,14 @@ message GetCommunityPostResponse {
   CommunityPostView post = 1;
 }
 
+message GetCommunityPostsRequest {
+  repeated string uris = 1;
+}
+
+message GetCommunityPostsResponse {
+  repeated CommunityPostView posts = 1;
+}
+
 message GetCommunityFeedByActorRequest {
   string actor_did = 1;
   int32 limit = 2;
@@ -2004,7 +2021,7 @@ message SubmitCommunityPostRequest {
 message SubmitCommunityPostResponse {
   string cid = 1;
   bool cid_verified = 2; // True if expectedCid was provided and matched
-  string rejected = 3; // Non-empty rejection code: ReplyNotAllowed | EmbeddingDisabled
+  string rejected = 3; // Non-empty rejection code: ReplyNotAllowed | EmbeddingDisabled | InvalidCreatedAt
 }
 
 message DeleteCommunityPostRequest {

--- a/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getAuthorFeed.ts
@@ -14,10 +14,17 @@ import {
 import { parseString } from '../../../../hydration/util.js'
 import { app } from '../../../../lexicons/index.js'
 import { createPipeline } from '../../../../pipeline.js'
-import { FeedType } from '../../../../proto/bsky_pb.js'
+import { CommunityPostView, FeedType } from '../../../../proto/bsky_pb.js'
 import { safePinnedPost, uriToDid } from '../../../../util/uris.js'
 import { Views } from '../../../../views/index.js'
+import { isCommunityUri } from '../../../community/blacksky/membership-guard.js'
+import {
+  presentCommunityFeedItem,
+  resolveCommunityMembership,
+} from '../../../community/blacksky/feed/mergedCommunityItems.js'
 import { clearlyBadCursor, resHeaders } from '../../../util.js'
+
+type FeedViewItem = ReturnType<Views['feedViewPost']>
 
 export default function (server: Server, ctx: AppContext) {
   const getAuthorFeed = createPipeline(
@@ -38,8 +45,12 @@ export default function (server: Server, ctx: AppContext) {
         includeTakedowns,
         skipViewerBlocks,
       })
+      const isCommunityMember = await resolveCommunityMembership(ctx, viewer)
 
-      const result = await getAuthorFeed({ ...params, hydrateCtx }, ctx)
+      const result = await getAuthorFeed(
+        { ...params, hydrateCtx, isCommunityMember },
+        ctx,
+      )
 
       const repoRev = await ctx.hydrator.actor.getRepoRevSafe(viewer)
 
@@ -97,6 +108,7 @@ export const skeleton = async (inputs: {
     limit: params.limit,
     cursor: params.cursor,
     feedType: FILTER_TO_FEED_TYPE[params.filter],
+    includeCommunityPosts: params.isCommunityMember,
   })
 
   let items: FeedItem[] = res.items.map((item) => ({
@@ -123,6 +135,9 @@ export const skeleton = async (inputs: {
     actor,
     filter: params.filter,
     items,
+    communityRows: params.isCommunityMember
+      ? new Map(res.communityPosts.map((row) => [row.uri, row]))
+      : undefined,
     cursor: parseString(res.cursor),
   }
 }
@@ -133,11 +148,48 @@ const hydration = async (inputs: {
   skeleton: Skeleton
 }): Promise<HydrationState> => {
   const { ctx, params, skeleton } = inputs
+  const standardItems = skeleton.items.filter(
+    (item) => !isCommunityUri(item.post.uri),
+  )
   const [feedPostState, profileViewerState] = await Promise.all([
-    ctx.hydrator.hydrateFeedItems(skeleton.items, params.hydrateCtx),
+    ctx.hydrator.hydrateFeedItems(standardItems, params.hydrateCtx),
     ctx.hydrator.hydrateProfileViewers([skeleton.actor.did], params.hydrateCtx),
+    buildCommunityViews(ctx, params, skeleton),
   ])
   return mergeStates(feedPostState, profileViewerState)
+}
+
+// Community items are built through the community view path (presentation is
+// synchronous, so views are prepared here) and spliced by position later.
+// Blocked/muted authors and broken replies come back undefined and drop.
+const buildCommunityViews = async (
+  ctx: Context,
+  params: Params,
+  skeleton: Skeleton,
+) => {
+  if (!skeleton.communityRows?.size) return
+  const helperCtx = {
+    hydrator: ctx.hydrator,
+    views: ctx.views,
+    dataplane: ctx.dataplane,
+  }
+  const entries = await Promise.all(
+    [...skeleton.communityRows.values()].map(
+      async (row) =>
+        [
+          row.uri,
+          await presentCommunityFeedItem(
+            helperCtx,
+            params.hydrateCtx,
+            row,
+            params.hydrateCtx.viewer ?? undefined,
+          ),
+        ] as const,
+    ),
+  )
+  skeleton.communityViews = new Map(
+    entries.flatMap(([uri, view]) => (view ? [[uri, view]] : [])),
+  )
 }
 
 const noBlocksOrMutedReposts = (inputs: {
@@ -178,7 +230,11 @@ const noBlocksOrMutedReposts = (inputs: {
   if (skeleton.filter === 'posts_and_author_threads') {
     // ensure replies are only included if the feed contains all
     // replies up to the thread root (i.e. a complete self-thread.)
-    const selfThread = new SelfThreadTracker(skeleton.items, hydration)
+    const selfThread = new SelfThreadTracker(
+      skeleton.items,
+      hydration,
+      communityParentsFromRows(skeleton.communityRows),
+    )
     skeleton.items = skeleton.items.filter((item) => {
       return (
         checkBlocksAndMutes(item) &&
@@ -198,9 +254,14 @@ const presentation = (inputs: {
   hydration: HydrationState
 }) => {
   const { ctx, skeleton, hydration } = inputs
-  const feed = mapDefined(skeleton.items, (item) =>
-    ctx.views.feedViewPost(item, hydration),
-  )
+  const feed = mapDefined(skeleton.items, (item) => {
+    if (isCommunityUri(item.post.uri)) {
+      // Community items render only through their pre-built views; a
+      // missing view means the item was dropped, never rendered publicly.
+      return skeleton.communityViews?.get(item.post.uri) as FeedViewItem
+    }
+    return ctx.views.feedViewPost(item, hydration)
+  })
   return { feed, cursor: skeleton.cursor }
 }
 
@@ -212,13 +273,32 @@ type Context = {
 
 type Params = app.bsky.feed.getAuthorFeed.$Params & {
   hydrateCtx: HydrateCtx
+  isCommunityMember: boolean
 }
 
 type Skeleton = {
   actor: Actor
   items: FeedItem[]
   filter: app.bsky.feed.getAuthorFeed.$Params['filter']
+  communityRows?: Map<string, CommunityPostView>
+  communityViews?: Map<string, Record<string, unknown>>
   cursor?: string
+}
+
+// Parent linkage for community rows so SelfThreadTracker can walk community
+// self-threads, which are absent from standard post hydration state.
+const communityParentsFromRows = (
+  rows?: Map<string, CommunityPostView>,
+): Map<AtUriString, AtUriString | null> => {
+  const map = new Map<AtUriString, AtUriString | null>()
+  if (!rows) return map
+  for (const row of rows.values()) {
+    map.set(
+      row.uri as AtUriString,
+      row.replyParent ? (row.replyParent as AtUriString) : null,
+    )
+  }
+  return map
 }
 
 class SelfThreadTracker {
@@ -228,6 +308,7 @@ class SelfThreadTracker {
   constructor(
     items: FeedItem[],
     private hydration: HydrationState,
+    private communityParents: Map<AtUriString, AtUriString | null> = new Map(),
   ) {
     items.forEach((item) => {
       if (!item.repost) {
@@ -258,6 +339,15 @@ class SelfThreadTracker {
     // must be in the feed to be in a self-thread
     if (!this.feedUris.has(uri)) {
       return false
+    }
+    // community posts live outside standard hydration; their parent
+    // linkage rides along with the skeleton rows instead.
+    if (this.communityParents.has(uri)) {
+      const communityParent = this.communityParents.get(uri) ?? null
+      if (communityParent === null) {
+        return true
+      }
+      return this.ok(communityParent, loop)
     }
     // must be hydratable to be part of self-thread
     const post = this.hydration.posts?.get(uri)

--- a/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getTimeline.ts
@@ -12,8 +12,16 @@ import {
 import { parseString } from '../../../../hydration/util.js'
 import { app } from '../../../../lexicons/index.js'
 import { createPipeline } from '../../../../pipeline.js'
+import { CommunityPostView } from '../../../../proto/bsky_pb.js'
 import { Views } from '../../../../views/index.js'
+import { isCommunityUri } from '../../../community/blacksky/membership-guard.js'
+import {
+  presentCommunityFeedItem,
+  resolveCommunityMembership,
+} from '../../../community/blacksky/feed/mergedCommunityItems.js'
 import { clearlyBadCursor, resHeaders } from '../../../util.js'
+
+type FeedViewItem = ReturnType<Views['feedViewPost']>
 
 export default function (server: Server, ctx: AppContext) {
   const getTimeline = createPipeline(
@@ -33,8 +41,12 @@ export default function (server: Server, ctx: AppContext) {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
+      const isCommunityMember = await resolveCommunityMembership(ctx, viewer)
 
-      const result = await getTimeline({ ...params, hydrateCtx }, ctx)
+      const result = await getTimeline(
+        { ...params, hydrateCtx, isCommunityMember },
+        ctx,
+      )
 
       const repoRev = await ctx.hydrator.actor.getRepoRevSafe(viewer)
 
@@ -59,6 +71,7 @@ export const skeleton = async (inputs: {
     actorDid: params.hydrateCtx.viewer,
     limit: params.limit,
     cursor: params.cursor,
+    includeCommunityPosts: params.isCommunityMember,
   })
   return {
     items: res.items.map((item) => ({
@@ -67,6 +80,9 @@ export const skeleton = async (inputs: {
         ? { uri: item.repost as AtUriString, cid: item.repostCid || undefined }
         : undefined,
     })),
+    communityRows: params.isCommunityMember
+      ? new Map(res.communityPosts.map((row) => [row.uri, row]))
+      : undefined,
     cursor: parseString(res.cursor),
   }
 }
@@ -77,7 +93,47 @@ const hydration = async (inputs: {
   skeleton: Skeleton
 }): Promise<HydrationState> => {
   const { ctx, params, skeleton } = inputs
-  return ctx.hydrator.hydrateFeedItems(skeleton.items, params.hydrateCtx)
+  const standardItems = skeleton.items.filter(
+    (item) => !isCommunityUri(item.post.uri),
+  )
+  const [state] = await Promise.all([
+    ctx.hydrator.hydrateFeedItems(standardItems, params.hydrateCtx),
+    buildCommunityViews(ctx, params, skeleton),
+  ])
+  return state
+}
+
+// Community items are built through the community view path (presentation is
+// synchronous, so views are prepared here) and spliced by position later.
+// Blocked/muted authors and broken replies come back undefined and drop.
+const buildCommunityViews = async (
+  ctx: Context,
+  params: Params,
+  skeleton: Skeleton,
+) => {
+  if (!skeleton.communityRows?.size) return
+  const helperCtx = {
+    hydrator: ctx.hydrator,
+    views: ctx.views,
+    dataplane: ctx.dataplane,
+  }
+  const entries = await Promise.all(
+    [...skeleton.communityRows.values()].map(
+      async (row) =>
+        [
+          row.uri,
+          await presentCommunityFeedItem(
+            helperCtx,
+            params.hydrateCtx,
+            row,
+            params.hydrateCtx.viewer,
+          ),
+        ] as const,
+    ),
+  )
+  skeleton.communityViews = new Map(
+    entries.flatMap(([uri, view]) => (view ? [[uri, view]] : [])),
+  )
 }
 
 const noBlocksOrMutes = (inputs: {
@@ -105,9 +161,14 @@ const presentation = (inputs: {
   hydration: HydrationState
 }) => {
   const { ctx, skeleton, hydration } = inputs
-  const feed = mapDefined(skeleton.items, (item) =>
-    ctx.views.feedViewPost(item, hydration),
-  )
+  const feed = mapDefined(skeleton.items, (item) => {
+    if (isCommunityUri(item.post.uri)) {
+      // Community items render only through their pre-built views; a
+      // missing view means the item was dropped, never rendered publicly.
+      return skeleton.communityViews?.get(item.post.uri) as FeedViewItem
+    }
+    return ctx.views.feedViewPost(item, hydration)
+  })
   return { feed, cursor: skeleton.cursor }
 }
 
@@ -119,9 +180,12 @@ type Context = {
 
 type Params = app.bsky.feed.getTimeline.$Params & {
   hydrateCtx: HydrateCtxWithViewer
+  isCommunityMember: boolean
 }
 
 type Skeleton = {
   items: FeedItem[]
+  communityRows?: Map<string, CommunityPostView>
+  communityViews?: Map<string, Record<string, unknown>>
   cursor?: string
 }

--- a/packages/bsky/src/api/community/blacksky/feed/getCommunityFeed.ts
+++ b/packages/bsky/src/api/community/blacksky/feed/getCommunityFeed.ts
@@ -7,6 +7,7 @@ import {
   buildCommunityPostView,
   isBlockedForViewer,
 } from '../views/communityPostView.js'
+import { buildReplyContext } from './mergedCommunityItems.js'
 
 export default function (server: Server, ctx: AppContext) {
   server.add(community.blacksky.feed.getCommunityFeed, {
@@ -79,41 +80,3 @@ export default function (server: Server, ctx: AppContext) {
   })
 }
 
-async function buildReplyContext(
-  helperCtx: any,
-  hydrateCtx: any,
-  row: any,
-  viewerDid?: string,
-) {
-  const parentUri = row.replyParent || ''
-  const rootUri = row.replyRoot || ''
-  if (!parentUri) return undefined
-  const [parentRes, rootRes] = await Promise.all([
-    helperCtx.dataplane.getCommunityPost({ uri: parentUri }),
-    rootUri && rootUri !== parentUri
-      ? helperCtx.dataplane.getCommunityPost({ uri: rootUri })
-      : Promise.resolve(null),
-  ])
-  if (!parentRes?.post) return undefined
-  const parentView = await buildCommunityPostView(
-    helperCtx,
-    hydrateCtx,
-    parentRes.post,
-    0,
-    viewerDid,
-  )
-  const rootView =
-    rootRes?.post
-      ? await buildCommunityPostView(
-          helperCtx,
-          hydrateCtx,
-          rootRes.post,
-          0,
-          viewerDid,
-        )
-      : parentView
-  if (isBlockedForViewer(parentView) || isBlockedForViewer(rootView)) {
-    return undefined
-  }
-  return { root: rootView, parent: parentView }
-}

--- a/packages/bsky/src/api/community/blacksky/feed/getCommunityTimeline.ts
+++ b/packages/bsky/src/api/community/blacksky/feed/getCommunityTimeline.ts
@@ -6,6 +6,7 @@ import {
   buildCommunityPostView,
   isBlockedForViewer,
 } from '../views/communityPostView.js'
+import { buildReplyContext } from './mergedCommunityItems.js'
 
 export default function (server: Server, ctx: AppContext) {
   server.add(community.blacksky.feed.getCommunityTimeline, {
@@ -70,42 +71,3 @@ export default function (server: Server, ctx: AppContext) {
   })
 }
 
-async function buildReplyContext(
-  helperCtx: any,
-  hydrateCtx: any,
-  row: any,
-  viewerDid?: string,
-) {
-  const parentUri = row.replyParent || ''
-  const rootUri = row.replyRoot || ''
-  if (!parentUri) return undefined
-  const [parentRes, rootRes] = await Promise.all([
-    helperCtx.dataplane.getCommunityPost({ uri: parentUri }),
-    rootUri && rootUri !== parentUri
-      ? helperCtx.dataplane.getCommunityPost({ uri: rootUri })
-      : Promise.resolve(null),
-  ])
-  if (!parentRes?.post) return undefined
-  const parentView = await buildCommunityPostView(
-    helperCtx,
-    hydrateCtx,
-    parentRes.post,
-    0,
-    viewerDid,
-  )
-  const rootView =
-    rootRes?.post
-      ? await buildCommunityPostView(
-          helperCtx,
-          hydrateCtx,
-          rootRes.post,
-          0,
-          viewerDid,
-        )
-      : parentView
-  // A blocked parent/root must not surface through reply context.
-  if (isBlockedForViewer(parentView) || isBlockedForViewer(rootView)) {
-    return undefined
-  }
-  return { root: rootView, parent: parentView }
-}

--- a/packages/bsky/src/api/community/blacksky/feed/mergedCommunityItems.ts
+++ b/packages/bsky/src/api/community/blacksky/feed/mergedCommunityItems.ts
@@ -1,0 +1,138 @@
+import { AppContext } from '../../../../context.js'
+import { communityPostsEnabled, isCommunityUri } from '../membership-guard.js'
+import {
+  buildCommunityPostView,
+  isBlockedForViewer,
+  isMutedForViewer,
+} from '../views/communityPostView.js'
+
+/**
+ * Resolve whether the viewer may see community posts on merged surfaces.
+ * Fail closed: any error, missing viewer, or disabled feature reads as
+ * non-member, so standard endpoints degrade to their pre-merge behavior
+ * rather than throwing or leaking.
+ */
+export async function resolveCommunityMembership(
+  ctx: AppContext,
+  viewer: string | null,
+): Promise<boolean> {
+  if (!communityPostsEnabled() || !viewer) return false
+  try {
+    const { isMember } = await ctx.dataplane.checkCommunityMembership({
+      did: viewer,
+    })
+    return isMember
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Drop community URIs from a skeleton unless the viewer is a member. The
+ * authoritative gate for feed-generator skeletons and any other source that
+ * can hand standard endpoints community URIs.
+ */
+export function filterCommunityUris<T extends { uri: string }>(
+  items: T[],
+  isMember: boolean,
+): T[] {
+  if (isMember) return items
+  return items.filter((item) => !isCommunityUri(item.uri))
+}
+
+type HelperCtx = {
+  hydrator: AppContext['hydrator']
+  views: AppContext['views']
+  dataplane: AppContext['dataplane']
+}
+
+type CommunityRow = {
+  uri: string
+  replyRoot?: string
+  replyParent?: string
+}
+
+/**
+ * Reply context (root/parent views) for a community reply row. Blocked or
+ * muted ancestors suppress the context entirely.
+ */
+export async function buildReplyContext(
+  helperCtx: HelperCtx,
+  hydrateCtx: unknown,
+  row: CommunityRow,
+  viewerDid?: string,
+) {
+  const parentUri = row.replyParent || ''
+  const rootUri = row.replyRoot || ''
+  if (!parentUri) return undefined
+  const [parentRes, rootRes] = await Promise.all([
+    helperCtx.dataplane.getCommunityPost({ uri: parentUri }),
+    rootUri && rootUri !== parentUri
+      ? helperCtx.dataplane.getCommunityPost({ uri: rootUri })
+      : Promise.resolve(null),
+  ])
+  if (!parentRes?.post) return undefined
+  const parentView = await buildCommunityPostView(
+    helperCtx as any,
+    hydrateCtx as any,
+    parentRes.post as any,
+    0,
+    viewerDid,
+  )
+  const rootView = rootRes?.post
+    ? await buildCommunityPostView(
+        helperCtx as any,
+        hydrateCtx as any,
+        rootRes.post as any,
+        0,
+        viewerDid,
+      )
+    : parentView
+  // Blocked or muted parent/root must not surface through reply context.
+  if (
+    isBlockedForViewer(parentView) ||
+    isBlockedForViewer(rootView) ||
+    isMutedForViewer(parentView) ||
+    isMutedForViewer(rootView)
+  ) {
+    return undefined
+  }
+  return { root: rootView, parent: parentView }
+}
+
+/**
+ * Build a feedViewPost-shaped item for a community row on a merged standard
+ * surface (timeline, author feed, and later getFeed). Returns undefined when
+ * the item must be dropped (blocked or muted author, or a reply whose
+ * ancestors are unavailable). Callers pass rows from the skeleton side
+ * channel; nothing is refetched for the post itself.
+ */
+export async function presentCommunityFeedItem(
+  helperCtx: HelperCtx,
+  hydrateCtx: unknown,
+  row: CommunityRow,
+  viewerDid?: string,
+): Promise<Record<string, unknown> | undefined> {
+  try {
+    const post = await buildCommunityPostView(
+      helperCtx as any,
+      hydrateCtx as any,
+      row as any,
+      0,
+      viewerDid,
+    )
+    if (!post) return undefined
+    if (isBlockedForViewer(post) || isMutedForViewer(post)) return undefined
+    if (row.replyParent) {
+      const reply = await buildReplyContext(helperCtx, hydrateCtx, row, viewerDid)
+      // A reply whose ancestors are blocked/muted/missing does not surface
+      // as a bare orphan on merged surfaces.
+      if (!reply) return undefined
+      return { post, reply }
+    }
+    return { post }
+  } catch {
+    // A failed community item degrades to absence, never to a 5xx.
+    return undefined
+  }
+}

--- a/packages/bsky/src/api/community/blacksky/feed/submitPost.ts
+++ b/packages/bsky/src/api/community/blacksky/feed/submitPost.ts
@@ -98,6 +98,11 @@ export default function (server: Server, ctx: AppContext) {
             ? JSON.stringify(embeddingRules)
             : '',
         })
+      if (rejected === 'InvalidCreatedAt') {
+        throw new InvalidRequestError(
+          'createdAt must be a canonical ISO-8601 timestamp',
+        )
+      }
       if (rejected === 'ReplyNotAllowed') {
         throw new InvalidRequestError(
           'The thread author has limited who can reply',

--- a/packages/bsky/src/api/community/blacksky/views/communityPostView.ts
+++ b/packages/bsky/src/api/community/blacksky/views/communityPostView.ts
@@ -162,6 +162,14 @@ export function isBlockedForViewer(
   return !!(viewer?.blocking || viewer?.blockedBy)
 }
 
+// True when the viewer mutes the built view's author (directly or via list).
+export function isMutedForViewer(
+  view: Record<string, unknown> | undefined,
+): boolean {
+  const viewer = (view?.author as { viewer?: Record<string, unknown> })?.viewer
+  return !!(viewer?.muted || viewer?.mutedByList)
+}
+
 type CommunityPostRow = {
   uri: string
   cid: string

--- a/packages/bsky/src/data-plane/server/routes/community-util.ts
+++ b/packages/bsky/src/data-plane/server/routes/community-util.ts
@@ -1,0 +1,25 @@
+// pg returns jsonb columns parsed; proto fields are typed `string`.
+export const jsonbToProtoString = (v: unknown): string =>
+  v == null ? '' : typeof v === 'string' ? v : JSON.stringify(v)
+
+export type CommunityPostRow = Record<string, string | null>
+
+export const communityPostFromRow = (row: CommunityPostRow) => ({
+  uri: row.uri ?? '',
+  cid: row.cid ?? '',
+  rkey: row.rkey ?? '',
+  creator: row.creator ?? '',
+  text: row.text ?? '',
+  facets: jsonbToProtoString(row.facets),
+  replyRoot: row.replyRoot ?? '',
+  replyRootCid: row.replyRootCid ?? '',
+  replyParent: row.replyParent ?? '',
+  replyParentCid: row.replyParentCid ?? '',
+  embed: jsonbToProtoString(row.embed),
+  langs: row.langs ?? '',
+  labels: jsonbToProtoString(row.labels),
+  tags: row.tags ?? '',
+  createdAt: row.createdAt ?? '',
+  indexedAt: row.indexedAt ?? '',
+  sortAt: row.sortAt ?? '',
+})

--- a/packages/bsky/src/data-plane/server/routes/community.ts
+++ b/packages/bsky/src/data-plane/server/routes/community.ts
@@ -5,6 +5,7 @@ import { CID } from 'multiformats/cid'
 import { sha256 } from 'multiformats/hashes/sha2'
 import { Service } from '../../../proto/bsky_connect.js'
 import { Database } from '../db/index.js'
+import { communityPostFromRow } from './community-util.js'
 
 function extractQuotedCommunityUri(embedJson: string): string | null {
   try {
@@ -108,10 +109,6 @@ const CACHE_MAX_SIZE = 100_000
 
 const MEMBERSHIP_LIST = process.env.COMMUNITY_MEMBERSHIP_LIST ?? 'blacksky'
 
-// pg returns jsonb columns parsed; proto fields are typed `string`.
-const jsonbToProtoString = (v: unknown): string =>
-  v == null ? '' : typeof v === 'string' ? v : JSON.stringify(v)
-
 export default (
   db: Database,
   membershipPool: pg.Pool | undefined,
@@ -161,25 +158,7 @@ export default (
       }
 
       return {
-        post: {
-          uri: row.uri,
-          cid: row.cid,
-          rkey: row.rkey,
-          creator: row.creator,
-          text: row.text,
-          facets: jsonbToProtoString(row.facets),
-          replyRoot: row.replyRoot ?? '',
-          replyRootCid: row.replyRootCid ?? '',
-          replyParent: row.replyParent ?? '',
-          replyParentCid: row.replyParentCid ?? '',
-          embed: jsonbToProtoString(row.embed),
-          langs: row.langs ?? '',
-          labels: jsonbToProtoString(row.labels),
-          tags: row.tags ?? '',
-          createdAt: row.createdAt,
-          indexedAt: row.indexedAt,
-          sortAt: row.sortAt,
-        },
+        post: communityPostFromRow(row),
       }
     },
 
@@ -202,25 +181,7 @@ export default (
       }
 
       return {
-        posts: rows.map((row: Record<string, string | null>) => ({
-          uri: row.uri ?? '',
-          cid: row.cid ?? '',
-          rkey: row.rkey ?? '',
-          creator: row.creator ?? '',
-          text: row.text ?? '',
-          facets: jsonbToProtoString(row.facets),
-          replyRoot: row.replyRoot ?? '',
-          replyRootCid: row.replyRootCid ?? '',
-          replyParent: row.replyParent ?? '',
-          replyParentCid: row.replyParentCid ?? '',
-          embed: jsonbToProtoString(row.embed),
-          langs: row.langs ?? '',
-          labels: jsonbToProtoString(row.labels),
-          tags: row.tags ?? '',
-          createdAt: row.createdAt ?? '',
-          indexedAt: row.indexedAt ?? '',
-          sortAt: row.sortAt ?? '',
-        })),
+        posts: rows.map(communityPostFromRow),
         cursor: nextCursor,
       }
     },
@@ -234,6 +195,17 @@ export default (
       })
 
       try {
+        // Merged-feed cursors compare sortAt strings; a non-canonical
+        // createdAt would mis-order against ISO keyset bounds. Rejecting
+        // (rather than rewriting) preserves the client-computed CID.
+        const createdAtDate = new Date(req.createdAt)
+        if (
+          isNaN(createdAtDate.getTime()) ||
+          createdAtDate.toISOString() !== req.createdAt
+        ) {
+          return { cid: '', cidVerified: false, rejected: 'InvalidCreatedAt' }
+        }
+
         const record: Record<string, unknown> = {
           $type: 'community.blacksky.feed.post',
           text: req.text,
@@ -408,25 +380,7 @@ export default (
       }
 
       return {
-        posts: rows.map((row: Record<string, string | null>) => ({
-          uri: row.uri ?? '',
-          cid: row.cid ?? '',
-          rkey: row.rkey ?? '',
-          creator: row.creator ?? '',
-          text: row.text ?? '',
-          facets: jsonbToProtoString(row.facets),
-          replyRoot: row.replyRoot ?? '',
-          replyRootCid: row.replyRootCid ?? '',
-          replyParent: row.replyParent ?? '',
-          replyParentCid: row.replyParentCid ?? '',
-          embed: jsonbToProtoString(row.embed),
-          langs: row.langs ?? '',
-          labels: jsonbToProtoString(row.labels),
-          tags: row.tags ?? '',
-          createdAt: row.createdAt ?? '',
-          indexedAt: row.indexedAt ?? '',
-          sortAt: row.sortAt ?? '',
-        })),
+        posts: rows.map(communityPostFromRow),
         cursor: nextCursor,
       }
     },
@@ -484,25 +438,7 @@ export default (
       }
 
       return {
-        posts: rows.map((row: Record<string, string | null>) => ({
-          uri: row.uri ?? '',
-          cid: row.cid ?? '',
-          rkey: row.rkey ?? '',
-          creator: row.creator ?? '',
-          text: row.text ?? '',
-          facets: jsonbToProtoString(row.facets),
-          replyRoot: row.replyRoot ?? '',
-          replyRootCid: row.replyRootCid ?? '',
-          replyParent: row.replyParent ?? '',
-          replyParentCid: row.replyParentCid ?? '',
-          embed: jsonbToProtoString(row.embed),
-          langs: row.langs ?? '',
-          labels: jsonbToProtoString(row.labels),
-          tags: row.tags ?? '',
-          createdAt: row.createdAt ?? '',
-          indexedAt: row.indexedAt ?? '',
-          sortAt: row.sortAt ?? '',
-        })),
+        posts: rows.map(communityPostFromRow),
         cursor: nextCursor,
       }
     },
@@ -558,25 +494,7 @@ export default (
       }
 
       return {
-        posts: rows.map((row: Record<string, string | null>) => ({
-          uri: row.uri ?? '',
-          cid: row.cid ?? '',
-          rkey: row.rkey ?? '',
-          creator: row.creator ?? '',
-          text: row.text ?? '',
-          facets: jsonbToProtoString(row.facets),
-          replyRoot: row.replyRoot ?? '',
-          replyRootCid: row.replyRootCid ?? '',
-          replyParent: row.replyParent ?? '',
-          replyParentCid: row.replyParentCid ?? '',
-          embed: jsonbToProtoString(row.embed),
-          langs: row.langs ?? '',
-          labels: jsonbToProtoString(row.labels),
-          tags: row.tags ?? '',
-          createdAt: row.createdAt ?? '',
-          indexedAt: row.indexedAt ?? '',
-          sortAt: row.sortAt ?? '',
-        })),
+        posts: rows.map(communityPostFromRow),
         cursor: nextCursor,
       }
     },

--- a/packages/bsky/src/data-plane/server/routes/feeds.ts
+++ b/packages/bsky/src/data-plane/server/routes/feeds.ts
@@ -1,9 +1,30 @@
-import { sql } from 'kysely'
+import { SqlBool, sql } from 'kysely'
 import { ServiceImpl } from '@connectrpc/connect'
 import { Service } from '../../../proto/bsky_connect.js'
 import { FeedType } from '../../../proto/bsky_pb.js'
 import { Database } from '../db/index.js'
 import { TimeCidKeyset, paginate } from '../db/pagination.js'
+import {
+  CommunityPostRow,
+  communityPostFromRow,
+} from './community-util.js'
+
+type SortableRow = { sortAt: string; cid: string }
+
+const bySortAtCidDesc = (a: SortableRow, b: SortableRow) => {
+  if (a.sortAt > b.sortAt) return -1
+  if (a.sortAt < b.sortAt) return 1
+  return a.cid > b.cid ? -1 : 1
+}
+
+const MEDIA_EMBED_TYPES = ['app.bsky.embed.images', 'app.bsky.embed.gallery']
+const VIDEO_EMBED_TYPES = [
+  'app.bsky.embed.video',
+  'community.blacksky.embed.video',
+]
+
+const embedTypeFilter = (types: string[]) =>
+  sql<SqlBool>`("embed"->>'$type' = any(${sql.val(types)}::text[]) OR "embed"->'media'->>'$type' = any(${sql.val(types)}::text[]))`
 
 export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
   async getAuthorFeed(req) {
@@ -82,9 +103,33 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
 
     const feedItems = await builder.execute()
 
+    if (!req.includeCommunityPosts) {
+      return {
+        items: feedItems.map(feedItemFromRow),
+        cursor: keyset.packFromResult(feedItems),
+      }
+    }
+
+    const communityRows = await getCommunityAuthorRows(db, {
+      actorDid,
+      limit,
+      cursor,
+      feedType,
+    })
+    const merged = mergeWithCommunityRows(
+      feedItems.map((row) => ({
+        sortAt: row.sortAt,
+        cid: row.cid,
+        item: feedItemFromRow(row),
+      })),
+      communityRows,
+      limit,
+    )
+
     return {
-      items: feedItems.map(feedItemFromRow),
-      cursor: keyset.packFromResult(feedItems),
+      items: merged.entries.map((m) => m.item),
+      cursor: keyset.packFromResult(merged.entries),
+      communityPosts: merged.communityPosts,
     }
   },
 
@@ -145,16 +190,35 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
     const selfRes = await selfQb.execute()
 
     const feedItems = [...followRes.rows, ...selfRes]
-      .sort((a, b) => {
-        if (a.sortAt > b.sortAt) return -1
-        if (a.sortAt < b.sortAt) return 1
-        return a.cid > b.cid ? -1 : 1
-      })
+      .sort(bySortAtCidDesc)
       .slice(0, limit)
 
+    if (!req.includeCommunityPosts) {
+      return {
+        items: feedItems.map(feedItemFromRow),
+        cursor: keyset.packFromResult(feedItems),
+      }
+    }
+
+    const communityRows = await getCommunityTimelineRows(db, {
+      actorDid,
+      limit,
+      cursorClause,
+    })
+    const merged = mergeWithCommunityRows(
+      feedItems.map((row) => ({
+        sortAt: row.sortAt,
+        cid: row.cid,
+        item: feedItemFromRow(row),
+      })),
+      communityRows,
+      limit,
+    )
+
     return {
-      items: feedItems.map(feedItemFromRow),
-      cursor: keyset.packFromResult(feedItems),
+      items: merged.entries.map((m) => m.item),
+      cursor: keyset.packFromResult(merged.entries),
+      communityPosts: merged.communityPosts,
     }
   },
 
@@ -204,4 +268,107 @@ const feedItemFromRow = (row: { postUri: string; uri: string }) => {
     uri: row.postUri,
     repost: row.uri === row.postUri ? undefined : row.uri,
   }
+}
+
+type CommunityQueryRow = CommunityPostRow & SortableRow & { uri: string }
+
+type MergeEntry = SortableRow & { item: { uri: string; repost?: string } }
+
+// Interleave community rows into an already-sorted standard skeleton by
+// (sortAt DESC, cid DESC), slicing to limit. Community rows for surviving
+// entries ride along so the caller never refetches them.
+const mergeWithCommunityRows = (
+  standardEntries: MergeEntry[],
+  communityRows: CommunityQueryRow[],
+  limit: number,
+) => {
+  const communityByUri = new Map(communityRows.map((row) => [row.uri, row]))
+  const entries = [
+    ...standardEntries,
+    ...communityRows.map((row) => ({
+      sortAt: row.sortAt,
+      cid: row.cid,
+      item: { uri: row.uri },
+    })),
+  ]
+    .sort(bySortAtCidDesc)
+    .slice(0, limit)
+  const communityPosts = entries
+    .map((m) => communityByUri.get(m.item.uri))
+    .filter((row) => row !== undefined)
+    .map((row) => communityPostFromRow(row))
+  return { entries, communityPosts }
+}
+
+// Community posts authored by DIDs the actor follows, plus the actor's own,
+// keyset-bounded to match the standard timeline pagination.
+const getCommunityTimelineRows = async (
+  db: Database,
+  opts: {
+    actorDid: string
+    limit: number
+    cursorClause: ReturnType<typeof sql>
+  },
+) => {
+  const { actorDid, limit, cursorClause } = opts
+  const res = await sql<CommunityQueryRow>`
+    SELECT cp.* FROM (
+      SELECT "subjectDid" FROM "follow" WHERE "creator" = ${actorDid}
+      UNION SELECT ${actorDid}
+    ) AS member
+    CROSS JOIN LATERAL (
+      SELECT * FROM "community_post"
+      WHERE "community_post"."creator" = member."subjectDid"
+        ${cursorClause}
+      ORDER BY "community_post"."sortAt" DESC, "community_post"."cid" DESC
+      LIMIT ${limit}
+    ) AS cp
+    ORDER BY cp."sortAt" DESC, cp."cid" DESC
+    LIMIT ${limit}
+  `.execute(db.db)
+  return res.rows
+}
+
+// The actor's community posts, filtered per the author-feed type and
+// keyset-bounded to match the standard author-feed pagination.
+const getCommunityAuthorRows = async (
+  db: Database,
+  opts: {
+    actorDid: string
+    limit: number
+    cursor?: string
+    feedType: FeedType
+  },
+): Promise<CommunityQueryRow[]> => {
+  const { actorDid, limit, cursor, feedType } = opts
+  const { ref } = db.db.dynamic
+
+  let builder = db.db
+    .selectFrom('community_post')
+    .selectAll()
+    .where('creator', '=', actorDid)
+
+  if (feedType === FeedType.POSTS_WITH_MEDIA) {
+    builder = builder.where(embedTypeFilter(MEDIA_EMBED_TYPES))
+  } else if (feedType === FeedType.POSTS_WITH_VIDEO) {
+    builder = builder.where(embedTypeFilter(VIDEO_EMBED_TYPES))
+  } else if (feedType === FeedType.POSTS_NO_REPLIES) {
+    builder = builder.where('replyParent', 'is', null)
+  } else if (feedType === FeedType.POSTS_AND_AUTHOR_THREADS) {
+    builder = builder.where((eb) =>
+      eb.or([
+        eb('replyParent', 'is', null),
+        eb('replyRoot', 'like', `at://${actorDid}/%`),
+      ]),
+    )
+  }
+
+  const keyset = new TimeCidKeyset(
+    ref('community_post.sortAt'),
+    ref('community_post.cid'),
+  )
+  builder = paginate(builder, { limit, cursor, keyset, tryIndex: true })
+
+  const rows = await builder.execute()
+  return rows as unknown as CommunityQueryRow[]
 }


### PR DESCRIPTION
Interleaves community posts into the Following timeline (follows + self) and profile author feeds, merged by (sortAt, cid) in the dataplane with the existing TimeCidKeyset cursor. Membership-gated fail-closed: non-members, logged-out viewers, and error paths get byte-identical pre-change responses. Community items render through the existing buildCommunityPostView path, now with mute filtering; includes GetCommunityPosts batch RPC and filterCommunityUris for the later getFeed phase.