### PR TITLE
fix(bsky): enforce mutes and blocks across community surfaces

### DIFF
--- a/packages/bsky/proto/bsky.proto
+++ b/packages/bsky/proto/bsky.proto
@@ -2021,7 +2021,7 @@ message SubmitCommunityPostRequest {
 message SubmitCommunityPostResponse {
   string cid = 1;
   bool cid_verified = 2; // True if expectedCid was provided and matched
-  string rejected = 3; // Non-empty rejection code: ReplyNotAllowed | EmbeddingDisabled | InvalidCreatedAt
+  string rejected = 3; // Non-empty rejection code: ReplyNotAllowed | EmbeddingDisabled | InvalidCreatedAt | BlockedFromReply
 }
 
 message DeleteCommunityPostRequest {

--- a/packages/bsky/src/api/app/bsky/feed/getQuotes.ts
+++ b/packages/bsky/src/api/app/bsky/feed/getQuotes.ts
@@ -5,7 +5,9 @@ import { AppContext } from '../../../../context.js'
 import { assertCommunityMembershipForUris } from '../../../community/blacksky/membership-guard.js'
 import {
   buildCommunityPostView,
+  isBlockedForViewer,
   isCommunityPostUri,
+  isMutedForViewer,
 } from '../../../community/blacksky/views/communityPostView.js'
 import {
   HydrateCtx,
@@ -52,16 +54,21 @@ export default function (server: Server, ctx: AppContext) {
           views: ctx.views,
           dataplane: ctx.dataplane,
         }
-        const posts = await Promise.all(
-          (quotesRes.posts ?? []).map((p: any) =>
-            buildCommunityPostView(
-              helperCtx as any,
-              hydrateCtx,
-              p,
-              0,
-              viewer ?? undefined,
+        const posts = (
+          await Promise.all(
+            (quotesRes.posts ?? []).map((p: any) =>
+              buildCommunityPostView(
+                helperCtx as any,
+                hydrateCtx,
+                p,
+                0,
+                viewer ?? undefined,
+              ),
             ),
-          ),
+          )
+        ).filter(
+          // Blocked or muted quoters never surface in the quotes list.
+          (view) => view && !isBlockedForViewer(view) && !isMutedForViewer(view),
         )
         return {
           encoding: 'application/json' as const,

--- a/packages/bsky/src/api/app/bsky/unspecced/getPostThreadV2.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getPostThreadV2.ts
@@ -23,6 +23,7 @@ import {
   buildCommunityPostView,
   isBlockedForViewer,
   isCommunityPostUri,
+  isMutedForViewer,
 } from '../../../community/blacksky/views/communityPostView.js'
 import { resHeaders } from '../../../util.js'
 
@@ -265,7 +266,7 @@ export default function (server: Server, ctx: AppContext) {
                         moreReplies: 0,
                         opThread: false,
                         hiddenByThreadgate: false,
-                        mutedByViewer: false,
+                        mutedByViewer: isMutedForViewer(view as any),
                       },
                     },
               ),
@@ -279,7 +280,7 @@ export default function (server: Server, ctx: AppContext) {
                   moreReplies: moreRepliesByUri.get(post.uri) ?? 0,
                   opThread: true,
                   hiddenByThreadgate: false,
-                  mutedByViewer: false,
+                  mutedByViewer: isMutedForViewer(anchorView as any),
                 },
               },
               ...descendantViews.map(({ uri, view, depth }) =>
@@ -296,7 +297,7 @@ export default function (server: Server, ctx: AppContext) {
                         opThread:
                           (byUri.get(uri)?.creator ?? '') === post.creator,
                         hiddenByThreadgate: false,
-                        mutedByViewer: false,
+                        mutedByViewer: isMutedForViewer(view as any),
                       },
                     },
               ),

--- a/packages/bsky/src/api/community/blacksky/feed/getCommunityFeed.ts
+++ b/packages/bsky/src/api/community/blacksky/feed/getCommunityFeed.ts
@@ -6,6 +6,7 @@ import { communityPostsEnabled } from '../membership-guard.js'
 import {
   buildCommunityPostView,
   isBlockedForViewer,
+  isMutedForViewer,
 } from '../views/communityPostView.js'
 import { buildReplyContext } from './mergedCommunityItems.js'
 
@@ -61,7 +62,9 @@ export default function (server: Server, ctx: AppContext) {
         await Promise.all(
           res.posts.map(async (row: any, i: number) => {
             const post = hydratedPosts[i]
-            if (isBlockedForViewer(post)) return null
+            if (isBlockedForViewer(post) || isMutedForViewer(post)) {
+              return null
+            }
             const reply = await buildReplyContext(
               helperCtx,
               hydrateCtx,

--- a/packages/bsky/src/api/community/blacksky/feed/getCommunityTimeline.ts
+++ b/packages/bsky/src/api/community/blacksky/feed/getCommunityTimeline.ts
@@ -5,6 +5,7 @@ import { communityPostsEnabled } from '../membership-guard.js'
 import {
   buildCommunityPostView,
   isBlockedForViewer,
+  isMutedForViewer,
 } from '../views/communityPostView.js'
 import { buildReplyContext } from './mergedCommunityItems.js'
 
@@ -52,7 +53,9 @@ export default function (server: Server, ctx: AppContext) {
         await Promise.all(
           res.posts.map(async (row: any, i: number) => {
             const post = hydratedPosts[i]
-            if (isBlockedForViewer(post)) return null
+            if (isBlockedForViewer(post) || isMutedForViewer(post)) {
+              return null
+            }
             const reply = await buildReplyContext(
               helperCtx,
               hydrateCtx,

--- a/packages/bsky/src/api/community/blacksky/feed/submitPost.ts
+++ b/packages/bsky/src/api/community/blacksky/feed/submitPost.ts
@@ -103,6 +103,12 @@ export default function (server: Server, ctx: AppContext) {
           'createdAt must be a canonical ISO-8601 timestamp',
         )
       }
+      if (rejected === 'BlockedFromReply') {
+        throw new InvalidRequestError(
+          'Cannot reply to this thread',
+          'BlockedActor',
+        )
+      }
       if (rejected === 'ReplyNotAllowed') {
         throw new InvalidRequestError(
           'The thread author has limited who can reply',

--- a/packages/bsky/src/data-plane/server/routes/community.ts
+++ b/packages/bsky/src/data-plane/server/routes/community.ts
@@ -21,6 +21,31 @@ function extractQuotedCommunityUri(embedJson: string): string | null {
   }
 }
 
+// True when a direct or list-based block exists in either direction.
+async function blockExistsBetween(
+  db: Database,
+  a: string,
+  b: string,
+): Promise<boolean> {
+  const direct = await db.pool.query(
+    `SELECT 1 FROM actor_block
+     WHERE (creator = $1 AND "subjectDid" = $2)
+        OR (creator = $2 AND "subjectDid" = $1)
+     LIMIT 1`,
+    [a, b],
+  )
+  if (direct.rowCount && direct.rowCount > 0) return true
+  const viaList = await db.pool.query(
+    `SELECT 1 FROM list_block lb
+     JOIN list_item li ON li."listUri" = lb."subjectUri"
+     WHERE (lb.creator = $1 AND li."subjectDid" = $2)
+        OR (lb.creator = $2 AND li."subjectDid" = $1)
+     LIMIT 1`,
+    [a, b],
+  )
+  return (viaList.rowCount ?? 0) > 0
+}
+
 async function threadgatePermitsReply(
   db: Database,
   opts: {
@@ -245,13 +270,32 @@ export default (
           return { cid: cidStr, cidVerified: false }
         }
 
-        // Threadgate: the root post's allow rules gate replies.
+        // Threadgate: the root post's allow rules gate replies. A block in
+        // either direction between the replier and the root or parent author
+        // severs the interaction entirely, matching app.bsky reply semantics.
         if (req.replyRoot) {
           const rootRes = await db.pool.query(
             `SELECT creator, facets, "threadgateAllow" FROM community_post WHERE uri = $1`,
             [req.replyRoot],
           )
           const root = rootRes.rows[0]
+          const ancestorAuthors = new Set<string>()
+          if (root?.creator) ancestorAuthors.add(root.creator)
+          if (req.replyParent && req.replyParent !== req.replyRoot) {
+            const parentRes = await db.pool.query(
+              `SELECT creator FROM community_post WHERE uri = $1`,
+              [req.replyParent],
+            )
+            if (parentRes.rows[0]?.creator) {
+              ancestorAuthors.add(parentRes.rows[0].creator)
+            }
+          }
+          ancestorAuthors.delete(req.creator)
+          for (const ancestor of ancestorAuthors) {
+            if (await blockExistsBetween(db, ancestor, req.creator)) {
+              return { cid: cidStr, cidVerified, rejected: 'BlockedFromReply' }
+            }
+          }
           if (root && root.threadgateAllow != null) {
             const allowed = await threadgatePermitsReply(db, {
               rules: root.threadgateAllow,
@@ -453,6 +497,9 @@ export default (
       const root = rootRes.rows[0]
       if (!root) return { allowed: true }
       if (root.creator === viewerDid) return { allowed: true }
+      if (await blockExistsBetween(db, root.creator, viewerDid)) {
+        return { allowed: false }
+      }
       if (root.threadgateAllow == null) return { allowed: true }
       const allowed = await threadgatePermitsReply(db, {
         rules: root.threadgateAllow,


### PR DESCRIPTION
Community threads now report real mutedByViewer (was hardcoded false), the community quotes branch drops blocked/muted quoters, the community tab API drops muted authors server-side, and community replies are rejected at submit when a direct or list block exists between the replier and the root/parent author (with checkCommunityReplyAllowed disabling the reply UI).