### PR TITLE
fix(bsky): community thread parity for muted replies, opThread, and moreParents

### DIFF
--- a/packages/bsky/src/api/app/bsky/unspecced/getPostThreadV2.ts
+++ b/packages/bsky/src/api/app/bsky/unspecced/getPostThreadV2.ts
@@ -16,7 +16,7 @@ import {
   createPipeline,
   noRules,
 } from '../../../../pipeline.js'
-import { postUriToThreadgateUri } from '../../../../util/uris.js'
+import { postUriToThreadgateUri, uriToDid } from '../../../../util/uris.js'
 import { Views } from '../../../../views/index.js'
 import { assertCommunityMembershipForUris } from '../../../community/blacksky/membership-guard.js'
 import {
@@ -139,6 +139,7 @@ export default function (server: Server, ctx: AppContext) {
           notFound?: boolean
           blocked?: boolean
         }> = []
+        let moreParentsAtTop = false
         if (params.above && post.replyParent) {
           const maxAbove = ctx.cfg.maxThreadParents ?? 80
           let parentUri: string | undefined = post.replyParent
@@ -179,8 +180,41 @@ export default function (server: Server, ctx: AppContext) {
             parentUri = parentRow.replyParent || undefined
             depth -= 1
           }
+          // Chain continues beyond the window: signal it on the topmost
+          // returned ancestor, matching the standard thread contract.
+          moreParentsAtTop = !!parentUri
         }
         ancestorViews.reverse()
+
+        // The OP thread is the unbroken chain of root-author self-replies
+        // starting at the thread root, matching standard thread semantics.
+        // Community post URIs always carry their creator as the authority,
+        // and getCommunityPostReplies loads the root's full descendant set.
+        const rootAuthor = uriToDid(threadRootUri)
+        const opChainUris = new Set<string>([threadRootUri])
+        {
+          const childUrisByParent = new Map<string, string[]>()
+          for (const p of allInThread) {
+            if (!p.replyParent) continue
+            const arr = childUrisByParent.get(p.replyParent) ?? []
+            arr.push(p.uri)
+            childUrisByParent.set(p.replyParent, arr)
+          }
+          let frontier: string[] = [threadRootUri]
+          while (frontier.length) {
+            const next: string[] = []
+            for (const u of frontier) {
+              for (const childUri of childUrisByParent.get(u) ?? []) {
+                const row = byUri.get(childUri)
+                if (row?.creator === rootAuthor && !opChainUris.has(childUri)) {
+                  opChainUris.add(childUri)
+                  next.push(childUri)
+                }
+              }
+            }
+            frontier = next
+          }
+        }
 
         // Depth-first assembly: each subtree's items are contiguous, which
         // is what the flattened threadItem contract requires.
@@ -225,7 +259,7 @@ export default function (server: Server, ctx: AppContext) {
           }
         }
         walk(post.uri, 1)
-        const descendantViews = await Promise.all(
+        const builtDescendants = await Promise.all(
           cappedDescendants.map(async ({ post: p, depth }) => ({
             uri: p.uri as string,
             depth,
@@ -239,36 +273,54 @@ export default function (server: Server, ctx: AppContext) {
             ),
           })),
         )
+        // Muted-author replies are excluded from the main tree with their
+        // whole subtree, matching how the standard pipeline buckets them
+        // out of thread[]. The flattened list is depth-first, so a subtree
+        // is the contiguous run of strictly deeper items.
+        const descendantViews: typeof builtDescendants = []
+        let skipDeeperThan: number | null = null
+        for (const item of builtDescendants) {
+          if (skipDeeperThan !== null) {
+            if (item.depth > skipDeeperThan) continue
+            skipDeeperThan = null
+          }
+          if (isMutedForViewer(item.view)) {
+            skipDeeperThan = item.depth
+            continue
+          }
+          descendantViews.push(item)
+        }
 
         return {
           encoding: 'application/json',
           body: {
             hasOtherReplies: false,
             thread: [
-              ...ancestorViews.map(({ uri, view, depth, notFound, blocked }) =>
-                notFound
-                  ? {
-                      uri,
-                      depth,
-                      value: {
-                        $type: 'app.bsky.unspecced.defs#threadItemNotFound',
-                      },
-                    }
-                  : blocked
-                    ? blockedItem(uri, depth, view)
-                    : {
-                      uri,
-                      depth,
-                      value: {
-                        $type: 'app.bsky.unspecced.defs#threadItemPost',
-                        post: view,
-                        moreParents: false,
-                        moreReplies: 0,
-                        opThread: false,
-                        hiddenByThreadgate: false,
-                        mutedByViewer: isMutedForViewer(view as any),
-                      },
-                    },
+              ...ancestorViews.map(
+                ({ uri, view, depth, notFound, blocked }, idx) =>
+                  notFound
+                    ? {
+                        uri,
+                        depth,
+                        value: {
+                          $type: 'app.bsky.unspecced.defs#threadItemNotFound',
+                        },
+                      }
+                    : blocked
+                      ? blockedItem(uri, depth, view)
+                      : {
+                          uri,
+                          depth,
+                          value: {
+                            $type: 'app.bsky.unspecced.defs#threadItemPost',
+                            post: view,
+                            moreParents: idx === 0 && moreParentsAtTop,
+                            moreReplies: 0,
+                            opThread: opChainUris.has(uri),
+                            hiddenByThreadgate: false,
+                            mutedByViewer: isMutedForViewer(view as any),
+                          },
+                        },
               ),
               {
                 uri: post.uri,
@@ -276,9 +328,12 @@ export default function (server: Server, ctx: AppContext) {
                 value: {
                   $type: 'app.bsky.unspecced.defs#threadItemPost',
                   post: anchorView,
-                  moreParents: false,
+                  moreParents:
+                    ancestorViews.length === 0 &&
+                    !!post.replyParent &&
+                    !params.above,
                   moreReplies: moreRepliesByUri.get(post.uri) ?? 0,
-                  opThread: true,
+                  opThread: opChainUris.has(post.uri),
                   hiddenByThreadgate: false,
                   mutedByViewer: isMutedForViewer(anchorView as any),
                 },
@@ -294,8 +349,7 @@ export default function (server: Server, ctx: AppContext) {
                         post: view,
                         moreParents: false,
                         moreReplies: moreRepliesByUri.get(uri) ?? 0,
-                        opThread:
-                          (byUri.get(uri)?.creator ?? '') === post.creator,
+                        opThread: opChainUris.has(uri),
                         hiddenByThreadgate: false,
                         mutedByViewer: isMutedForViewer(view as any),
                       },


### PR DESCRIPTION
Muted-author replies are excluded from community thread trees with their subtrees (standard clients never read mutedByViewer on main-tree items), opThread is computed as the unbroken root-author self-reply chain, and moreParents signals truncated ancestor windows. Known gaps left for follow-up: threadgate hiddenReplies storage, the 200-reply thread cap, and a community getPostThreadOtherV2 branch.