### PR TITLE
fix(bsky): crash-isolate push retry loop and bound maintenance sweeps

### DIFF
--- a/packages/bsky/src/data-plane/server/notification-push-bridge.ts
+++ b/packages/bsky/src/data-plane/server/notification-push-bridge.ts
@@ -21,6 +21,10 @@ import {
 } from './notification-push-copy.js'
 
 const CHANNEL = 'notification_push_inserted'
+// Runaway backstop for the batched maintenance sweeps: even a fully backed-up
+// outbox is cleared over successive retry ticks rather than in one unbounded
+// pass, so a single tick never scans the whole table.
+const MAX_MAINTENANCE_BATCHES = 50
 const DEFAULT_ENABLED_REASONS = new Set([
   'follow',
   'like',
@@ -56,6 +60,7 @@ export type NotificationPushBridgeConfig = {
   retryIntervalMs: number
   maxAttempts: number
   ttlHours: number
+  maintenanceBatchSize: number
 }
 
 export type NotificationRow = {
@@ -569,9 +574,18 @@ export class NotificationPushBridge {
     if (this.retryTimer || this.stopped) return
     this.retryTimer = setTimeout(() => {
       this.retryTimer = undefined
-      this.activeRetry = this.processRetryBatch().finally(() => {
-        this.scheduleRetry()
-      })
+      // Crash isolation: a rejection here (e.g. a statement timeout on the
+      // outbox) must never reach Node's unhandledRejection handler, which would
+      // exit(1) and take down the entire dataplane process. Swallow and log,
+      // then always reschedule so the loop self-heals on the next tick. Mirrors
+      // the try/catch already guarding flush().
+      this.activeRetry = this.processRetryBatch()
+        .catch((err) => {
+          console.error('[notification-push-bridge] retry batch failed', err)
+        })
+        .finally(() => {
+          this.scheduleRetry()
+        })
     }, delayMs)
   }
 
@@ -688,28 +702,60 @@ export class NotificationPushBridge {
     })
   }
 
+  // Bounded maintenance sweep: rewriting every matching row in one UPDATE can
+  // cross the connection statement_timeout once the outbox holds tens of
+  // millions of rows — the aborted statement then rolls back, leaves dead
+  // tuples, and each retry is slower (the crash-loop bloat ratchet). Instead
+  // flip rows in id-keyed batches until a sweep affects fewer than a full
+  // batch. Each batch changes status out of the matched set, so the loop
+  // converges. Bounded by a hard iteration cap as a runaway backstop.
   private async expireOutboxRows() {
-    await this.db.db
-      .updateTable('notification_push_outbox')
-      .set({ status: 'expired', updatedAt: new Date() })
-      .where('status', 'in', ['pending', 'retryable', 'processing'])
-      .where('expiresAt', '<=', new Date())
-      .execute()
+    const now = new Date()
+    const limit = this.cfg.maintenanceBatchSize
+    for (let i = 0; i < MAX_MAINTENANCE_BATCHES; i++) {
+      if (this.stopped) return
+      const res = await this.db.db
+        .updateTable('notification_push_outbox')
+        .set({ status: 'expired', updatedAt: new Date() })
+        .where('id', 'in', (eb) =>
+          eb
+            .selectFrom('notification_push_outbox')
+            .select('id')
+            .where('status', 'in', ['pending', 'retryable', 'processing'])
+            .where('expiresAt', '<=', now)
+            .limit(limit),
+        )
+        .executeTakeFirst()
+      if (Number(res.numUpdatedRows ?? 0) < limit) return
+    }
   }
 
   private async reclaimStaleProcessingRows() {
-    await this.db.db
-      .updateTable('notification_push_outbox')
-      .set({
-        status: 'retryable',
-        nextAttemptAt: new Date(),
-        lastError: 'retry processing timeout',
-        updatedAt: new Date(),
-      })
-      .where('status', '=', 'processing')
-      .where('updatedAt', '<', new Date(Date.now() - this.processingTimeoutMs))
-      .where('expiresAt', '>', new Date())
-      .execute()
+    const staleBefore = new Date(Date.now() - this.processingTimeoutMs)
+    const now = new Date()
+    const limit = this.cfg.maintenanceBatchSize
+    for (let i = 0; i < MAX_MAINTENANCE_BATCHES; i++) {
+      if (this.stopped) return
+      const res = await this.db.db
+        .updateTable('notification_push_outbox')
+        .set({
+          status: 'retryable',
+          nextAttemptAt: new Date(),
+          lastError: 'retry processing timeout',
+          updatedAt: new Date(),
+        })
+        .where('id', 'in', (eb) =>
+          eb
+            .selectFrom('notification_push_outbox')
+            .select('id')
+            .where('status', '=', 'processing')
+            .where('updatedAt', '<', staleBefore)
+            .where('expiresAt', '>', now)
+            .limit(limit),
+        )
+        .executeTakeFirst()
+      if (Number(res.numUpdatedRows ?? 0) < limit) return
+    }
   }
 }
 
@@ -747,6 +793,10 @@ export const parseNotificationPushBridgeConfigFromEnv =
       ),
       ttlHours: parseInt(
         process.env.BSKY_NOTIFICATION_PUSH_TTL_HOURS || '24',
+        10,
+      ),
+      maintenanceBatchSize: parseInt(
+        process.env.BSKY_NOTIFICATION_PUSH_MAINTENANCE_BATCH_SIZE || '5000',
         10,
       ),
     }

--- a/packages/bsky/tests/data-plane/notification-push-bridge.test.ts
+++ b/packages/bsky/tests/data-plane/notification-push-bridge.test.ts
@@ -377,8 +377,11 @@ describe('notification push bridge', () => {
     expect(rows[0].courierNotificationId).toBe(getCourierNotificationId(row))
   })
 
-  function createBridge(pushNotifications: ReturnType<typeof vi.fn>) {
-    return new NotificationPushBridge(db, testConfig(), {
+  function createBridge(
+    pushNotifications: ReturnType<typeof vi.fn>,
+    configOverrides: Partial<NotificationPushBridgeConfig> = {},
+  ) {
+    return new NotificationPushBridge(db, testConfig(configOverrides), {
       courierClient: { pushNotifications } as any,
     })
   }
@@ -749,9 +752,52 @@ describe('notification push bridge', () => {
     expect(statusByNotifId.get(blocked.id)).toBe('suppressed')
     expect(statusByNotifId.get(allowed.id)).toBe('sent')
   })
+
+  // Regression: the retry loop must be crash-isolated. A rejection escaping
+  // processRetryBatch() previously reached Node's unhandledRejection handler
+  // and exited the whole dataplane process (~1,872 restart cycles). scheduleRetry
+  // must swallow the rejection and reschedule instead.
+  it('does not let a rejecting retry batch escape the scheduler', async () => {
+    const bridge: any = createBridge(vi.fn())
+    vi.spyOn(bridge, 'processRetryBatch').mockRejectedValue(
+      new Error('canceling statement due to statement timeout'),
+    )
+
+    bridge.stopped = false
+    bridge.scheduleRetry(0)
+    // let the timer fire once
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    bridge.stopped = true // prevent further rescheduling
+
+    // The tracked promise resolves (rejection was caught), never rejects.
+    await expect(bridge.activeRetry).resolves.toBeUndefined()
+  })
+
+  // Regression: maintenance sweeps must be bounded. A single unbounded UPDATE
+  // over tens of millions of rows crossed statement_timeout, aborted, and
+  // bloated the table. With a small batch size the loop must still clear a
+  // backlog larger than one batch.
+  it('expires a backlog larger than one maintenance batch', async () => {
+    const expiredAt = new Date(Date.now() - 60_000)
+    for (let i = 0; i < 7; i++) {
+      const row = notificationRow({
+        recordUri: `at://did:plc:actor/app.bsky.feed.like/stale-${i}`,
+      })
+      await insertOutbox(row, { status: 'pending', expiresAt: expiredAt })
+    }
+
+    const bridge: any = createBridge(vi.fn(), { maintenanceBatchSize: 2 })
+    await bridge.processRetryBatchOnceForTest()
+
+    const rows = await outboxRows()
+    expect(rows).toHaveLength(7)
+    expect(rows.every((r) => r.status === 'expired')).toBe(true)
+  })
 })
 
-function notificationRow(): NotificationRow {
+function notificationRow(
+  overrides: Partial<NotificationRow> = {},
+): NotificationRow {
   return {
     id: 1,
     did: 'did:plc:recipient',
@@ -761,10 +807,13 @@ function notificationRow(): NotificationRow {
     reason: 'like',
     reasonSubject: 'at://did:plc:recipient/app.bsky.feed.post/root',
     sortAt: new Date().toISOString(),
+    ...overrides,
   }
 }
 
-function testConfig(): NotificationPushBridgeConfig {
+function testConfig(
+  overrides: Partial<NotificationPushBridgeConfig> = {},
+): NotificationPushBridgeConfig {
   return {
     enabled: true,
     courierUrl: 'http://courier.test',
@@ -776,5 +825,7 @@ function testConfig(): NotificationPushBridgeConfig {
     retryIntervalMs: 100,
     maxAttempts: 10,
     ttlHours: 24,
+    maintenanceBatchSize: 5000,
+    ...overrides,
   }
 }


### PR DESCRIPTION
The notification push bridge could take down the entire dataplane process:

1. scheduleRetry() ran processRetryBatch().finally(reschedule) with no catch, so a rejection (e.g. a statement timeout on notification_push_outbox) escaped to Node's unhandledRejection handler and exit(1)'d the process. systemd restarted it, the retry timer fired ~60s later, and the cycle repeated (~1,872 restarts observed), surfacing as intermittent 500s across every AppView endpoint while the dataplane port was down.

2. expireOutboxRows() and reclaimStaleProcessingRows() each rewrote every matching row in a single unbounded UPDATE. Once the outbox held tens of millions of rows this crossed the connection statement_timeout, aborted, and left dead tuples — making each subsequent attempt slower.

Fixes:
- scheduleRetry now .catch()es and logs the rejection before rescheduling, so a failing batch self-heals on the next tick instead of killing the host.
- Both maintenance sweeps run as id-keyed batched loops (LIMIT maintenanceBatchSize, default 5000 via BSKY_NOTIFICATION_PUSH_MAINTENANCE_BATCH_SIZE), bounded by a hard iteration backstop, so no single tick scans the whole table.

Does NOT address the structural intake > drain-rate imbalance that let the backlog grow unbounded in the first place (follow-up).

Tests: a rejecting retry batch no longer escapes the scheduler; a backlog larger than one maintenance batch is fully expired.