### PR TITLE
fix(bsky): bounded list-membership lookups, relationship subquery limits, image stream error handling

### DIFF
--- a/packages/bsky/src/data-plane/server/routes/relationships.ts
+++ b/packages/bsky/src/data-plane/server/routes/relationships.ts
@@ -54,12 +54,14 @@ export default (
             .where('actor_block.creator', '=', actorDid)
             .whereRef('actor_block.subjectDid', '=', ref('actor.did'))
             .select('uri')
+            .limit(1)
             .as('blocking'),
           db.db
             .selectFrom('actor_block')
             .where('actor_block.subjectDid', '=', actorDid)
             .whereRef('actor_block.creator', '=', ref('actor.did'))
             .select('uri')
+            .limit(1)
             .as('blockedBy'),
           db.db
             .selectFrom('list_item')
@@ -82,12 +84,14 @@ export default (
             .where('follow.creator', '=', actorDid)
             .whereRef('follow.subjectDid', '=', ref('actor.did'))
             .select('uri')
+            .limit(1)
             .as('following'),
           db.db
             .selectFrom('follow')
             .where('follow.subjectDid', '=', actorDid)
             .whereRef('follow.creator', '=', ref('actor.did'))
             .select('uri')
+            .limit(1)
             .as('followedBy'),
         ])
         .execute()
@@ -152,6 +156,7 @@ export default (
             .whereRef('actor_block.creator', '=', sourceRef)
             .whereRef('actor_block.subjectDid', '=', targetRef)
             .select('uri')
+            .limit(1)
             .as('blocking'),
         (eb) =>
           eb
@@ -159,6 +164,7 @@ export default (
             .whereRef('actor_block.creator', '=', targetRef)
             .whereRef('actor_block.subjectDid', '=', sourceRef)
             .select('uri')
+            .limit(1)
             .as('blockedBy'),
         (eb) =>
           eb

--- a/packages/bsky/src/data-plane/server/routes/relationships.ts
+++ b/packages/bsky/src/data-plane/server/routes/relationships.ts
@@ -6,6 +6,54 @@ import { RelationshipCache, CachedRelationship } from '../cache'
 import { Database } from '../db'
 import { valuesList } from '../db/util'
 
+// List-membership checks are resolved via these bounded lookups rather than
+// scalar subqueries joining list_item by subject: actors can appear in
+// hundreds of thousands of list_items, and the planner driving from that
+// side stalls the query for tens of seconds.
+const getListBlocksByCreator = async (
+  db: Database,
+  creators: string[],
+): Promise<Map<string, string[]>> => {
+  const byCreator = new Map<string, string[]>()
+  if (creators.length === 0) return byCreator
+  const rows = await db.db
+    .selectFrom('list_block')
+    .where('creator', 'in', creators)
+    .select(['creator', 'subjectUri'])
+    .execute()
+  for (const row of rows) {
+    const uris = byCreator.get(row.creator) ?? []
+    uris.push(row.subjectUri)
+    byCreator.set(row.creator, uris)
+  }
+  return byCreator
+}
+
+const getListMemberships = async (
+  db: Database,
+  listUris: string[],
+  subjectDids: string[],
+): Promise<Set<string>> => {
+  if (listUris.length === 0 || subjectDids.length === 0) return new Set()
+  const rows = await db.db
+    .selectFrom('list_item')
+    .where('listUri', 'in', [...new Set(listUris)])
+    .where('subjectDid', 'in', [...new Set(subjectDids)])
+    .select(['listUri', 'subjectDid'])
+    .execute()
+  return new Set(rows.map((row) => membershipKey(row.listUri, row.subjectDid)))
+}
+
+const membershipKey = (listUri: string, did: string) => `${listUri}\n${did}`
+
+const firstListedIn = (
+  listUris: string[],
+  did: string,
+  memberships: Set<string>,
+): string => {
+  return listUris.find((uri) => memberships.has(membershipKey(uri, did))) ?? ''
+}
+
 export default (
   db: Database,
   cache?: RelationshipCache,
@@ -24,78 +72,98 @@ export default (
       needFetch = targetDids.filter((did) => !cached.has(did))
     }
 
-    // Fetch uncached from DB. List-membership subqueries use .limit(1) to
-    // avoid "scalar subquery returned multiple rows" errors when an actor
-    // appears in more than one mute/block list.
+    // Fetch uncached from DB. Scalar subqueries use .limit(1) to avoid
+    // "more than one row returned by a subquery" on duplicate rows.
     let byDid = new Map<string, Record<string, unknown>>()
     if (needFetch.length > 0) {
       const { ref } = db.db.dynamic
-      const res = await db.db
-        .selectFrom('actor')
-        .where('did', 'in', needFetch)
-        .select([
-          'actor.did',
-          db.db
-            .selectFrom('mute')
-            .where('mute.mutedByDid', '=', actorDid)
-            .whereRef('mute.subjectDid', '=', ref('actor.did'))
-            .select(sql<true>`${true}`.as('val'))
-            .as('muted'),
-          db.db
-            .selectFrom('list_item')
-            .innerJoin('list_mute', 'list_mute.listUri', 'list_item.listUri')
-            .where('list_mute.mutedByDid', '=', actorDid)
-            .whereRef('list_item.subjectDid', '=', ref('actor.did'))
-            .select('list_item.listUri')
-            .limit(1)
-            .as('mutedByList'),
-          db.db
-            .selectFrom('actor_block')
-            .where('actor_block.creator', '=', actorDid)
-            .whereRef('actor_block.subjectDid', '=', ref('actor.did'))
-            .select('uri')
-            .limit(1)
-            .as('blocking'),
-          db.db
-            .selectFrom('actor_block')
-            .where('actor_block.subjectDid', '=', actorDid)
-            .whereRef('actor_block.creator', '=', ref('actor.did'))
-            .select('uri')
-            .limit(1)
-            .as('blockedBy'),
-          db.db
-            .selectFrom('list_item')
-            .innerJoin('list_block', 'list_block.subjectUri', 'list_item.listUri')
-            .where('list_block.creator', '=', actorDid)
-            .whereRef('list_item.subjectDid', '=', ref('actor.did'))
-            .select('list_item.listUri')
-            .limit(1)
-            .as('blockingByList'),
-          db.db
-            .selectFrom('list_item')
-            .innerJoin('list_block', 'list_block.subjectUri', 'list_item.listUri')
-            .where('list_item.subjectDid', '=', actorDid)
-            .whereRef('list_block.creator', '=', ref('actor.did'))
-            .select('list_item.listUri')
-            .limit(1)
-            .as('blockedByList'),
-          db.db
-            .selectFrom('follow')
-            .where('follow.creator', '=', actorDid)
-            .whereRef('follow.subjectDid', '=', ref('actor.did'))
-            .select('uri')
-            .limit(1)
-            .as('following'),
-          db.db
-            .selectFrom('follow')
-            .where('follow.subjectDid', '=', actorDid)
-            .whereRef('follow.creator', '=', ref('actor.did'))
-            .select('uri')
-            .limit(1)
-            .as('followedBy'),
-        ])
-        .execute()
+      const [muteListRows, blockListsByCreator, res] = await Promise.all([
+        actorDid
+          ? db.db
+              .selectFrom('list_mute')
+              .where('mutedByDid', '=', actorDid)
+              .select('listUri')
+              .execute()
+          : [],
+        getListBlocksByCreator(
+          db,
+          actorDid ? [actorDid, ...needFetch] : needFetch,
+        ),
+        db.db
+          .selectFrom('actor')
+          .where('did', 'in', needFetch)
+          .select([
+            'actor.did',
+            db.db
+              .selectFrom('mute')
+              .where('mute.mutedByDid', '=', actorDid)
+              .whereRef('mute.subjectDid', '=', ref('actor.did'))
+              .select(sql<true>`${true}`.as('val'))
+              .as('muted'),
+            db.db
+              .selectFrom('actor_block')
+              .where('actor_block.creator', '=', actorDid)
+              .whereRef('actor_block.subjectDid', '=', ref('actor.did'))
+              .select('uri')
+              .limit(1)
+              .as('blocking'),
+            db.db
+              .selectFrom('actor_block')
+              .where('actor_block.subjectDid', '=', actorDid)
+              .whereRef('actor_block.creator', '=', ref('actor.did'))
+              .select('uri')
+              .limit(1)
+              .as('blockedBy'),
+            db.db
+              .selectFrom('follow')
+              .where('follow.creator', '=', actorDid)
+              .whereRef('follow.subjectDid', '=', ref('actor.did'))
+              .select('uri')
+              .limit(1)
+              .as('following'),
+            db.db
+              .selectFrom('follow')
+              .where('follow.subjectDid', '=', actorDid)
+              .whereRef('follow.creator', '=', ref('actor.did'))
+              .select('uri')
+              .limit(1)
+              .as('followedBy'),
+          ])
+          .execute(),
+      ])
+
+      const viewerMuteLists = muteListRows.map((row) => row.listUri)
+      const viewerBlockLists = actorDid
+        ? (blockListsByCreator.get(actorDid) ?? [])
+        : []
+      const targetBlockLists = needFetch.flatMap(
+        (did) => blockListsByCreator.get(did) ?? [],
+      )
+      const [targetMemberships, viewerMemberships] = await Promise.all([
+        getListMemberships(
+          db,
+          [...viewerMuteLists, ...viewerBlockLists],
+          needFetch,
+        ),
+        getListMemberships(db, targetBlockLists, actorDid ? [actorDid] : []),
+      ])
+
       byDid = keyBy(res, 'did')
+      for (const did of needFetch) {
+        const row = byDid.get(did)
+        if (!row) continue
+        row.mutedByList = firstListedIn(viewerMuteLists, did, targetMemberships)
+        row.blockingByList = firstListedIn(
+          viewerBlockLists,
+          did,
+          targetMemberships,
+        )
+        row.blockedByList = firstListedIn(
+          blockListsByCreator.get(did) ?? [],
+          actorDid,
+          viewerMemberships,
+        )
+      }
 
       // Cache the fetched results
       if (cache && actorDid) {
@@ -145,60 +213,55 @@ export default (
     const sourceRef = ref('pair.source')
     const targetRef = ref('pair.target')
     const values = valuesList(pairs.map((p) => sql`${p.a}, ${p.b}`))
-    const res = await db.db
-      .selectFrom(values.as(sql`pair (source, target)`))
-      .select([
-        sql<string>`${sourceRef}`.as('source'),
-        sql<string>`${targetRef}`.as('target'),
-        (eb) =>
-          eb
-            .selectFrom('actor_block')
-            .whereRef('actor_block.creator', '=', sourceRef)
-            .whereRef('actor_block.subjectDid', '=', targetRef)
-            .select('uri')
-            .limit(1)
-            .as('blocking'),
-        (eb) =>
-          eb
-            .selectFrom('actor_block')
-            .whereRef('actor_block.creator', '=', targetRef)
-            .whereRef('actor_block.subjectDid', '=', sourceRef)
-            .select('uri')
-            .limit(1)
-            .as('blockedBy'),
-        (eb) =>
-          eb
-            .selectFrom('list_item')
-            .innerJoin(
-              'list_block',
-              'list_block.subjectUri',
-              'list_item.listUri',
-            )
-            .whereRef('list_block.creator', '=', sourceRef)
-            .whereRef('list_item.subjectDid', '=', targetRef)
-            .select('list_item.listUri')
-            .limit(1)
-            .as('blockingByList'),
-        (eb) =>
-          eb
-            .selectFrom('list_item')
-            .innerJoin(
-              'list_block',
-              'list_block.subjectUri',
-              'list_item.listUri',
-            )
-            .whereRef('list_block.creator', '=', targetRef)
-            .whereRef('list_item.subjectDid', '=', sourceRef)
-            .select('list_item.listUri')
-            .limit(1)
-            .as('blockedByList'),
-      ])
-      .execute()
+    const pairDids = [...new Set(pairs.flatMap((p) => [p.a, p.b]))]
+    const [blockListsByCreator, res] = await Promise.all([
+      getListBlocksByCreator(db, pairDids),
+      db.db
+        .selectFrom(values.as(sql`pair (source, target)`))
+        .select([
+          sql<string>`${sourceRef}`.as('source'),
+          sql<string>`${targetRef}`.as('target'),
+          (eb) =>
+            eb
+              .selectFrom('actor_block')
+              .whereRef('actor_block.creator', '=', sourceRef)
+              .whereRef('actor_block.subjectDid', '=', targetRef)
+              .select('uri')
+              .limit(1)
+              .as('blocking'),
+          (eb) =>
+            eb
+              .selectFrom('actor_block')
+              .whereRef('actor_block.creator', '=', targetRef)
+              .whereRef('actor_block.subjectDid', '=', sourceRef)
+              .select('uri')
+              .limit(1)
+              .as('blockedBy'),
+        ])
+        .execute(),
+    ])
+    const allBlockLists = pairDids.flatMap(
+      (did) => blockListsByCreator.get(did) ?? [],
+    )
+    const memberships = await getListMemberships(db, allBlockLists, pairDids)
+    const withListBlocks = res.map((cur) => ({
+      ...cur,
+      blockingByList: firstListedIn(
+        blockListsByCreator.get(cur.source) ?? [],
+        cur.target,
+        memberships,
+      ),
+      blockedByList: firstListedIn(
+        blockListsByCreator.get(cur.target) ?? [],
+        cur.source,
+        memberships,
+      ),
+    }))
     const getKey = (a, b) => [a, b].sort().join(',')
-    const lookup = res.reduce((acc, cur) => {
+    const lookup = withListBlocks.reduce((acc, cur) => {
       const key = getKey(cur.source, cur.target)
       return acc.set(key, cur)
-    }, new Map<string, (typeof res)[0]>())
+    }, new Map<string, (typeof withListBlocks)[0]>())
     return {
       exists: pairs.map((pair) => {
         const item = lookup.get(getKey(pair.a, pair.b))

--- a/packages/bsky/src/image/server.ts
+++ b/packages/bsky/src/image/server.ts
@@ -99,9 +99,15 @@ export function createMiddleware(
         ]
         const processor = createImageProcessor(options)
 
-        // Cache in the background
+        // Cache in the background. The clone needs its own error listener:
+        // forwarded processor errors can fire before cache.put consumes the
+        // stream, and an unlistened 'error' event brings down the process.
+        const cacheStream = cloneStream(processor)
+        cacheStream.on('error', (err) =>
+          log.warn({ err }, 'image cache stream error'),
+        )
         cache
-          .put(cacheKey, cloneStream(processor))
+          .put(cacheKey, cacheStream)
           .catch((err) => log.error({ err }, 'failed to cache image'))
 
         res.statusCode = 200


### PR DESCRIPTION
Resolves list-based relationship state (mutedByList, blockingByList, blockedByList) via bounded lookups driven from the per-user list tables instead of scalar subqueries joined through list_item by subject, which stalled for subjects appearing in very large numbers of lists. Also limits the scalar relationship subqueries to one row and handles image cache stream errors so a malformed blob cannot crash the process.

## Test plan
- [x] package builds clean
- [x] query plans verified as bounded index probes
- [x] previously stalling and erroring requests verified returning correct results