### PR TITLE
fix(bsky): propagate forceRefresh to dataplane identity lookup

### DIFF
--- a/packages/bsky/package.json
+++ b/packages/bsky/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atproto/bsky",
-  "version": "0.0.247",
+  "version": "0.0.248",
   "license": "MIT",
   "description": "Reference implementation of app.bsky App View (Bluesky API)",
   "keywords": [

--- a/packages/bsky/proto/bsky.proto
+++ b/packages/bsky/proto/bsky.proto
@@ -1379,6 +1379,7 @@ message GetLatestRevResponse {
 
 message GetIdentityByDidRequest {
   string did = 1;
+  bool force_refresh = 2;
 }
 message GetIdentityByDidResponse {
   string did = 1;

--- a/packages/bsky/src/auth-verifier.ts
+++ b/packages/bsky/src/auth-verifier.ts
@@ -312,7 +312,7 @@ export class AuthVerifier {
   >(reqCtx: ReqCtx, opts: TOptions) {
     const getSigningKey = async (
       iss: string,
-      _forceRefresh: boolean, // @TODO consider propagating to dataplane
+      forceRefresh: boolean,
     ): Promise<string> => {
       if (opts.iss !== null && !opts.iss.includes(iss)) {
         throw new AuthRequiredError('Untrusted issuer', 'UntrustedIss')
@@ -326,7 +326,7 @@ export class AuthVerifier {
         serviceId === 'atproto_labeler' ? 'atproto_label' : 'atproto'
       let identity: GetIdentityByDidResponse
       try {
-        identity = await this.dataplane.getIdentityByDid({ did })
+        identity = await this.dataplane.getIdentityByDid({ did, forceRefresh })
       } catch (err) {
         if (isDataplaneError(err, Code.NotFound)) {
           throw new AuthRequiredError('identity unknown')

--- a/packages/bsky/src/data-plane/server/routes/identity.ts
+++ b/packages/bsky/src/data-plane/server/routes/identity.ts
@@ -9,7 +9,7 @@ export default (
   idResolver: IdResolver,
 ): Partial<ServiceImpl<typeof Service>> => ({
   async getIdentityByDid(req) {
-    const doc = await idResolver.did.resolve(req.did)
+    const doc = await idResolver.did.resolve(req.did, req.forceRefresh)
     if (!doc) {
       throw new ConnectError('identity not found', Code.NotFound)
     }


### PR DESCRIPTION
The service-JWT verifier retries with a forced DID-doc refresh when the first signature check fails (recent key rotation / account migration), but the appview dropped the flag on the appview->dataplane hop, so the retry re-read the same stale in-memory MemoryCache entry and auth failed with "jwt signature does not match jwt issuer" until the cache went stale on its own (up to ~1h).

Add force_refresh to GetIdentityByDidRequest and thread it through getSigningKey -> getIdentityByDid -> idResolver.did.resolve so the retry bypasses the cache and re-resolves against PLC, self-healing on the first failed request. Flag defaults to false; all other callers keep cache use.