### PR TITLE
feat(bsky): synthesize boilerplate records from typed tables

### DIFF
--- a/packages/bsky/src/data-plane/server/db/migrations/20260804T100000000Z-typed-record-fidelity.ts
+++ b/packages/bsky/src/data-plane/server/db/migrations/20260804T100000000Z-typed-record-fidelity.ts
@@ -1,26 +1,31 @@
 import { Kysely, sql } from 'kysely'
 
-// Idempotent: production may already carry these columns from the
-// out-of-band DDL applied ahead of the record-table migration.
+// Idempotent AND privilege-safe: production already carries these columns
+// from out-of-band DDL, and ALTER TABLE demands table ownership even with
+// IF NOT EXISTS, so existence is checked first via information_schema.
+const addColumnIfMissing = async (
+  db: Kysely<unknown>,
+  table: string,
+  column: string,
+) => {
+  const res = await sql<{ n: number }>`
+    SELECT count(*)::int AS n FROM information_schema.columns
+    WHERE table_schema = current_schema() AND table_name = ${table} AND column_name = ${column}
+  `.execute(db)
+  if (res.rows[0]?.n === 0) {
+    await sql`ALTER TABLE ${sql.table(table)} ADD COLUMN ${sql.ref(column)} varchar`.execute(
+      db,
+    )
+  }
+}
+
 export async function up(db: Kysely<unknown>): Promise<void> {
-  await sql`ALTER TABLE follow ADD COLUMN IF NOT EXISTS "via" varchar`.execute(
-    db,
-  )
-  await sql`ALTER TABLE follow ADD COLUMN IF NOT EXISTS "viaCid" varchar`.execute(
-    db,
-  )
-  await sql`ALTER TABLE "like" ADD COLUMN IF NOT EXISTS "takedownRef" varchar`.execute(
-    db,
-  )
-  await sql`ALTER TABLE repost ADD COLUMN IF NOT EXISTS "takedownRef" varchar`.execute(
-    db,
-  )
-  await sql`ALTER TABLE follow ADD COLUMN IF NOT EXISTS "takedownRef" varchar`.execute(
-    db,
-  )
-  await sql`ALTER TABLE actor_block ADD COLUMN IF NOT EXISTS "takedownRef" varchar`.execute(
-    db,
-  )
+  await addColumnIfMissing(db, 'follow', 'via')
+  await addColumnIfMissing(db, 'follow', 'viaCid')
+  await addColumnIfMissing(db, 'like', 'takedownRef')
+  await addColumnIfMissing(db, 'repost', 'takedownRef')
+  await addColumnIfMissing(db, 'follow', 'takedownRef')
+  await addColumnIfMissing(db, 'actor_block', 'takedownRef')
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {

--- a/packages/bsky/src/data-plane/server/db/migrations/20260804T100000000Z-typed-record-fidelity.ts
+++ b/packages/bsky/src/data-plane/server/db/migrations/20260804T100000000Z-typed-record-fidelity.ts
@@ -1,0 +1,35 @@
+import { Kysely, sql } from 'kysely'
+
+// Idempotent: production may already carry these columns from the
+// out-of-band DDL applied ahead of the record-table migration.
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE follow ADD COLUMN IF NOT EXISTS "via" varchar`.execute(
+    db,
+  )
+  await sql`ALTER TABLE follow ADD COLUMN IF NOT EXISTS "viaCid" varchar`.execute(
+    db,
+  )
+  await sql`ALTER TABLE "like" ADD COLUMN IF NOT EXISTS "takedownRef" varchar`.execute(
+    db,
+  )
+  await sql`ALTER TABLE repost ADD COLUMN IF NOT EXISTS "takedownRef" varchar`.execute(
+    db,
+  )
+  await sql`ALTER TABLE follow ADD COLUMN IF NOT EXISTS "takedownRef" varchar`.execute(
+    db,
+  )
+  await sql`ALTER TABLE actor_block ADD COLUMN IF NOT EXISTS "takedownRef" varchar`.execute(
+    db,
+  )
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE actor_block DROP COLUMN IF EXISTS "takedownRef"`.execute(
+    db,
+  )
+  await sql`ALTER TABLE follow DROP COLUMN IF EXISTS "takedownRef"`.execute(db)
+  await sql`ALTER TABLE repost DROP COLUMN IF EXISTS "takedownRef"`.execute(db)
+  await sql`ALTER TABLE "like" DROP COLUMN IF EXISTS "takedownRef"`.execute(db)
+  await sql`ALTER TABLE follow DROP COLUMN IF EXISTS "viaCid"`.execute(db)
+  await sql`ALTER TABLE follow DROP COLUMN IF EXISTS "via"`.execute(db)
+}

--- a/packages/bsky/src/data-plane/server/db/migrations/index.ts
+++ b/packages/bsky/src/data-plane/server/db/migrations/index.ts
@@ -65,3 +65,4 @@ export * as _20260625T200000000Z from './20260625T200000000Z-add-peer-mod-labels
 export * as _20260625T210000000Z from './20260625T210000000Z-notification-push-bridge.js'
 export * as _20260702T210000000Z from './20260702T210000000Z-add-actor-badges.js'
 export * as _20260703T150000000Z from './20260703T150000000Z-community-post-gates.js'
+export * as _20260804T100000000Z from './20260804T100000000Z-typed-record-fidelity.js'

--- a/packages/bsky/src/data-plane/server/db/tables/actor-block.ts
+++ b/packages/bsky/src/data-plane/server/db/tables/actor-block.ts
@@ -9,6 +9,7 @@ export interface ActorBlock {
   createdAt: string
   indexedAt: string
   sortAt: GeneratedAlways<string>
+  takedownRef: string | null
 }
 
 export type PartialDB = { [tableName]: ActorBlock }

--- a/packages/bsky/src/data-plane/server/db/tables/follow.ts
+++ b/packages/bsky/src/data-plane/server/db/tables/follow.ts
@@ -7,9 +7,12 @@ export interface Follow {
   cid: string
   creator: string
   subjectDid: string
+  via: string | null
+  viaCid: string | null
   createdAt: string
   indexedAt: string
   sortAt: GeneratedAlways<string>
+  takedownRef: string | null
 }
 
 export type PartialDB = { [tableName]: Follow }

--- a/packages/bsky/src/data-plane/server/db/tables/like.ts
+++ b/packages/bsky/src/data-plane/server/db/tables/like.ts
@@ -13,6 +13,7 @@ export interface Like {
   createdAt: string
   indexedAt: string
   sortAt: GeneratedAlways<string>
+  takedownRef: string | null
 }
 
 export type PartialDB = { [tableName]: Like }

--- a/packages/bsky/src/data-plane/server/db/tables/repost.ts
+++ b/packages/bsky/src/data-plane/server/db/tables/repost.ts
@@ -13,6 +13,7 @@ export interface Repost {
   createdAt: string
   indexedAt: string
   sortAt: GeneratedAlways<string>
+  takedownRef: string | null
 }
 
 export type PartialDB = { [tableName]: Repost }

--- a/packages/bsky/src/data-plane/server/notification-push-bridge.ts
+++ b/packages/bsky/src/data-plane/server/notification-push-bridge.ts
@@ -413,11 +413,41 @@ export class NotificationPushBridge {
             ]),
           )
           .execute(),
+        // Takedown state for like/follow/repost/block lives on the typed
+        // tables (their record rows are being dropped); union both homes.
         this.db.db
           .selectFrom('record')
           .select('uri')
           .where('uri', 'in', recordUris)
           .where('takedownRef', 'is not', null)
+          .unionAll(
+            this.db.db
+              .selectFrom('like')
+              .select('uri')
+              .where('uri', 'in', recordUris)
+              .where('takedownRef', 'is not', null),
+          )
+          .unionAll(
+            this.db.db
+              .selectFrom('repost')
+              .select('uri')
+              .where('uri', 'in', recordUris)
+              .where('takedownRef', 'is not', null),
+          )
+          .unionAll(
+            this.db.db
+              .selectFrom('follow')
+              .select('uri')
+              .where('uri', 'in', recordUris)
+              .where('takedownRef', 'is not', null),
+          )
+          .unionAll(
+            this.db.db
+              .selectFrom('actor_block')
+              .select('uri')
+              .where('uri', 'in', recordUris)
+              .where('takedownRef', 'is not', null),
+          )
           .execute(),
       ])
     // Blocks are bidirectional: a block in either direction hides the notif.

--- a/packages/bsky/src/data-plane/server/routes/moderation.ts
+++ b/packages/bsky/src/data-plane/server/routes/moderation.ts
@@ -1,6 +1,24 @@
 import { ServiceImpl } from '@connectrpc/connect'
+import { AtUri } from '@atproto/syntax'
 import { Service } from '../../../proto/bsky_connect.js'
 import { Database } from '../db/index.js'
+
+// Takedown state for like/follow/repost/block lives on the typed tables
+// (their record rows are being dropped); everything else stays on record.
+const takedownTableForUri = (uri: string) => {
+  switch (new AtUri(uri).collection) {
+    case 'app.bsky.feed.like':
+      return 'like' as const
+    case 'app.bsky.feed.repost':
+      return 'repost' as const
+    case 'app.bsky.graph.follow':
+      return 'follow' as const
+    case 'app.bsky.graph.block':
+      return 'actor_block' as const
+    default:
+      return 'record' as const
+  }
+}
 
 export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
   async getActorTakedown(req) {
@@ -33,7 +51,7 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
   async getRecordTakedown(req) {
     const { recordUri } = req
     const res = await db.db
-      .selectFrom('record')
+      .selectFrom(takedownTableForUri(recordUri))
       .where('uri', '=', recordUri)
       .select('takedownRef')
       .executeTakeFirst()
@@ -67,7 +85,7 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
   async takedownRecord(req) {
     const { recordUri, ref } = req
     await db.db
-      .updateTable('record')
+      .updateTable(takedownTableForUri(recordUri))
       .set({ takedownRef: ref || 'TAKEDOWN' })
       .where('uri', '=', recordUri)
       .execute()
@@ -94,7 +112,7 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
   async untakedownRecord(req) {
     const { recordUri } = req
     await db.db
-      .updateTable('record')
+      .updateTable(takedownTableForUri(recordUri))
       .set({ takedownRef: null })
       .where('uri', '=', recordUri)
       .execute()

--- a/packages/bsky/src/data-plane/server/routes/notifs.ts
+++ b/packages/bsky/src/data-plane/server/routes/notifs.ts
@@ -30,16 +30,21 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
     let builder = db.db
       .selectFrom('notification as notif')
       .where('notif.did', '=', actorDid)
-      .where((eb) =>
-        eb.or([
-          eb('reasonSubject', 'is', null),
-          eb.exists(
-            db.db
-              .selectFrom('record as subject')
-              .selectAll()
-              .whereRef('subject.uri', '=', ref('notif.reasonSubject')),
-          ),
-        ]),
+      // Subject-existence dispatches by collection: like/follow/repost/block
+      // live in the typed tables (their record rows are being dropped), the
+      // rest still resolve through the record store. reasonSubject is usually
+      // a post uri, but via-repost reasons carry the repost uri.
+      .where(
+        sql<boolean>`(
+          notif."reasonSubject" IS NULL OR
+          CASE split_part(notif."reasonSubject", '/', 4)
+            WHEN 'app.bsky.feed.like' THEN EXISTS (SELECT 1 FROM "like" l WHERE l.uri = notif."reasonSubject")
+            WHEN 'app.bsky.feed.repost' THEN EXISTS (SELECT 1 FROM repost rp WHERE rp.uri = notif."reasonSubject")
+            WHEN 'app.bsky.graph.follow' THEN EXISTS (SELECT 1 FROM follow f WHERE f.uri = notif."reasonSubject")
+            WHEN 'app.bsky.graph.block' THEN EXISTS (SELECT 1 FROM actor_block ab WHERE ab.uri = notif."reasonSubject")
+            ELSE EXISTS (SELECT 1 FROM record r WHERE r.uri = notif."reasonSubject")
+          END
+        )`,
       )
       .$if(priority, (qb) => qb.where(({ exists }) => exists(priorityFollowQb)))
       .select([
@@ -110,8 +115,21 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       .select(countAll.as('count'))
       .innerJoin('actor', 'actor.did', 'notification.did')
       .leftJoin('actor_state', 'actor_state.did', 'actor.did')
-      .innerJoin('record', 'record.uri', 'notification.recordUri')
-      .where(notSoftDeletedClause(ref('record')))
+      // Existence + takedown gate dispatches by collection: recordUri for
+      // like/follow/repost/block notifications resolves in the typed tables
+      // (their record rows are being dropped), everything else in record.
+      // All arms are uri primary-key probes.
+      .where(
+        sql<boolean>`(
+          CASE split_part(notification."recordUri", '/', 4)
+            WHEN 'app.bsky.feed.like' THEN EXISTS (SELECT 1 FROM "like" l WHERE l.uri = notification."recordUri" AND l."takedownRef" IS NULL)
+            WHEN 'app.bsky.feed.repost' THEN EXISTS (SELECT 1 FROM repost rp WHERE rp.uri = notification."recordUri" AND rp."takedownRef" IS NULL)
+            WHEN 'app.bsky.graph.follow' THEN EXISTS (SELECT 1 FROM follow f WHERE f.uri = notification."recordUri" AND f."takedownRef" IS NULL)
+            WHEN 'app.bsky.graph.block' THEN EXISTS (SELECT 1 FROM actor_block ab WHERE ab.uri = notification."recordUri" AND ab."takedownRef" IS NULL)
+            ELSE EXISTS (SELECT 1 FROM record r WHERE r.uri = notification."recordUri" AND r."takedownRef" IS NULL)
+          END
+        )`,
+      )
       .where(notSoftDeletedClause(ref('actor')))
       // Ensure to hit notification_did_sortat_idx, handling case where lastSeenNotifs is null.
       .where('notification.did', '=', actorDid)

--- a/packages/bsky/src/data-plane/server/routes/records.ts
+++ b/packages/bsky/src/data-plane/server/routes/records.ts
@@ -11,16 +11,16 @@ import { PostRecordMeta, Record } from '../../../proto/bsky_pb.js'
 import { Database } from '../db/index.js'
 
 export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
-  getBlockRecords: getRecords(db, app.bsky.graph.block),
+  getBlockRecords: getBlockRecordsSynthesized(db),
   getFeedGeneratorRecords: getRecords(db, app.bsky.feed.generator),
-  getFollowRecords: getRecords(db, app.bsky.graph.follow),
-  getLikeRecords: getRecords(db, app.bsky.feed.like),
+  getFollowRecords: getFollowRecordsSynthesized(db),
+  getLikeRecords: getLikeRecordsSynthesized(db),
   getListBlockRecords: getRecords(db, app.bsky.graph.listblock),
   getListItemRecords: getRecords(db, app.bsky.graph.listitem),
   getListRecords: getRecords(db, app.bsky.graph.list),
   getPostRecords: getPostRecords(db),
   getProfileRecords: getRecords(db, app.bsky.actor.profile),
-  getRepostRecords: getRecords(db, app.bsky.feed.repost),
+  getRepostRecords: getRepostRecordsSynthesized(db),
   getThreadGateRecords: getRecords(db, app.bsky.feed.threadgate),
   getPostgateRecords: getRecords(db, app.bsky.feed.postgate),
   getLabelerRecords: getRecords(db, app.bsky.labeler.service),
@@ -94,6 +94,185 @@ export const getRecords = (db: Database, ns?: l.Main<l.RecordSchema>) => {
     return { records }
   }
 }
+
+// Like/follow/repost/block records are synthesized from the typed tables
+// instead of read from the record store: their content is fully reconstructible
+// (subject, createdAt, via attribution), which lets the record table drop those
+// rows. Raw createdAt byte-fidelity and unknown extra fields are not preserved,
+// so the returned value is not re-hashable to `cid` (which stays the original
+// commit cid from index time).
+
+type SynthesizedRow = {
+  uri: string
+  cid: string
+  createdAt: string
+  indexedAt: string
+  takedownRef: string | null
+  value: { [k: string]: unknown }
+}
+
+const synthesizedRecords = (
+  collection: string,
+  fetchRows: (uris: string[]) => Promise<SynthesizedRow[]>,
+) => {
+  return async (req: { uris: string[] }): Promise<{ records: Record[] }> => {
+    const validUris = req.uris.filter(
+      (uri) => new AtUri(uri).collection === collection,
+    )
+    const rows = validUris.length ? await fetchRows(validUris) : []
+    const byUri = keyBy(rows, 'uri')
+    const records: Record[] = req.uris.map((uri) => {
+      const row = byUri.get(uri)
+      if (!row) {
+        return new Record({
+          record: ui8.fromString(
+            JSON.stringify(null),
+            'utf8',
+          ) as Uint8Array<ArrayBuffer>,
+        })
+      }
+      const createdAtRaw = new Date(row.createdAt)
+      const createdAt = !isNaN(createdAtRaw.getTime())
+        ? Timestamp.fromDate(createdAtRaw)
+        : undefined
+      const indexedAt = row.indexedAt
+        ? Timestamp.fromDate(new Date(row.indexedAt))
+        : undefined
+      return new Record({
+        record: ui8.fromString(
+          JSON.stringify(row.value),
+          'utf8',
+        ) as Uint8Array<ArrayBuffer>,
+        cid: row.cid,
+        createdAt,
+        indexedAt,
+        sortedAt: compositeTime(createdAt, indexedAt),
+        takenDown: !!row.takedownRef,
+        takedownRef: row.takedownRef ?? undefined,
+      })
+    })
+    return { records }
+  }
+}
+
+const viaRef = (via: string | null, viaCid: string | null) =>
+  via ? { via: viaCid ? { uri: via, cid: viaCid } : { uri: via } } : {}
+
+export const getLikeRecordsSynthesized = (db: Database) =>
+  synthesizedRecords('app.bsky.feed.like', async (uris) => {
+    const rows = await db.db
+      .selectFrom('like')
+      .select([
+        'uri',
+        'cid',
+        'subject',
+        'subjectCid',
+        'via',
+        'viaCid',
+        'createdAt',
+        'indexedAt',
+        'takedownRef',
+      ])
+      .where('uri', 'in', uris)
+      .execute()
+    return rows.map((r) => ({
+      uri: r.uri,
+      cid: r.cid,
+      createdAt: r.createdAt,
+      indexedAt: r.indexedAt,
+      takedownRef: r.takedownRef,
+      value: {
+        $type: 'app.bsky.feed.like',
+        subject: { uri: r.subject, cid: r.subjectCid },
+        createdAt: r.createdAt,
+        ...viaRef(r.via, r.viaCid),
+      },
+    }))
+  })
+
+export const getRepostRecordsSynthesized = (db: Database) =>
+  synthesizedRecords('app.bsky.feed.repost', async (uris) => {
+    const rows = await db.db
+      .selectFrom('repost')
+      .select([
+        'uri',
+        'cid',
+        'subject',
+        'subjectCid',
+        'via',
+        'viaCid',
+        'createdAt',
+        'indexedAt',
+        'takedownRef',
+      ])
+      .where('uri', 'in', uris)
+      .execute()
+    return rows.map((r) => ({
+      uri: r.uri,
+      cid: r.cid,
+      createdAt: r.createdAt,
+      indexedAt: r.indexedAt,
+      takedownRef: r.takedownRef,
+      value: {
+        $type: 'app.bsky.feed.repost',
+        subject: { uri: r.subject, cid: r.subjectCid },
+        createdAt: r.createdAt,
+        ...viaRef(r.via, r.viaCid),
+      },
+    }))
+  })
+
+export const getFollowRecordsSynthesized = (db: Database) =>
+  synthesizedRecords('app.bsky.graph.follow', async (uris) => {
+    const rows = await db.db
+      .selectFrom('follow')
+      .select([
+        'uri',
+        'cid',
+        'subjectDid',
+        'via',
+        'viaCid',
+        'createdAt',
+        'indexedAt',
+        'takedownRef',
+      ])
+      .where('uri', 'in', uris)
+      .execute()
+    return rows.map((r) => ({
+      uri: r.uri,
+      cid: r.cid,
+      createdAt: r.createdAt,
+      indexedAt: r.indexedAt,
+      takedownRef: r.takedownRef,
+      value: {
+        $type: 'app.bsky.graph.follow',
+        subject: r.subjectDid,
+        createdAt: r.createdAt,
+        ...viaRef(r.via, r.viaCid),
+      },
+    }))
+  })
+
+export const getBlockRecordsSynthesized = (db: Database) =>
+  synthesizedRecords('app.bsky.graph.block', async (uris) => {
+    const rows = await db.db
+      .selectFrom('actor_block')
+      .select(['uri', 'cid', 'subjectDid', 'createdAt', 'indexedAt', 'takedownRef'])
+      .where('uri', 'in', uris)
+      .execute()
+    return rows.map((r) => ({
+      uri: r.uri,
+      cid: r.cid,
+      createdAt: r.createdAt,
+      indexedAt: r.indexedAt,
+      takedownRef: r.takedownRef,
+      value: {
+        $type: 'app.bsky.graph.block',
+        subject: r.subjectDid,
+        createdAt: r.createdAt,
+      },
+    }))
+  })
 
 export const getPostRecords = (db: Database) => {
   const getBaseRecords = getRecords(db, app.bsky.feed.post)

--- a/packages/bsky/src/hydration/util.ts
+++ b/packages/bsky/src/hydration/util.ts
@@ -98,6 +98,9 @@ export function parseRecord<TSchema extends RecordSchema>(
   // that the caller gets the same data as what is stored in the PDS (in case of
   // records). This is important because the receiver of the data should be able
   // to compute the right record CID.
+  // Exception: like/follow/repost/block records are synthesized from typed
+  // tables (normalized createdAt, no unknown fields), so their returned value
+  // is not re-hashable to `cid`; `cid` remains the original commit cid.
 
   if (!recordSchema.$matches(record, PARSE_OPTIONS)) {
     return undefined


### PR DESCRIPTION
Reconstructs like/follow/repost/block records from their typed rows and dispatches notification existence, unread counts, and record takedown state by collection, so the record table can drop those rows.