### PR TITLE
fix(bsky): handle image cache stream errors to prevent process crash

### DIFF
--- a/packages/bsky/src/image/server.ts
+++ b/packages/bsky/src/image/server.ts
@@ -99,9 +99,15 @@ export function createMiddleware(
         ]
         const processor = createImageProcessor(options)
 
-        // Cache in the background
+        // Cache in the background. The clone needs its own error listener:
+        // forwarded processor errors can fire before cache.put consumes the
+        // stream, and an unlistened 'error' event brings down the process.
+        const cacheStream = cloneStream(processor)
+        cacheStream.on('error', (err) =>
+          log.warn({ err }, 'image cache stream error'),
+        )
         cache
-          .put(cacheKey, cloneStream(processor))
+          .put(cacheKey, cacheStream)
           .catch((err) => log.error({ err }, 'failed to cache image'))
 
         res.statusCode = 200


### PR DESCRIPTION
The background cache write clones the processor stream without an error listener, so a processor error emitted before the cache consumes the clone raises an unhandled 'error' event and brings down the process. Attach a listener to the clone and log instead.

## Test plan
- [x] package builds clean
- [x] running in production since mid-July with the crash signature absent