### PR TITLE
fix(bsky): honor mute scopes in push notification suppression

### DIFF
--- a/.changeset/push-bridge-mute-scope.md
+++ b/.changeset/push-bridge-mute-scope.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Honor mute scopes when suppressing push notifications. The push bridge treated any `mute` row for a (recipient, author) pair as a full mute, but a scoped mute (`onlyReposts` / `onlyQuoteposts`) restricts the mute to that content rather than muting the account, so a scoped mute silently suppressed every push notification from that account while `listNotifications` continued to show them. Suppression now applies only to unscoped mutes, matching `getRelationships` and `getActorMutesActor`.

--- a/packages/bsky/src/data-plane/server/notification-push-bridge.ts
+++ b/packages/bsky/src/data-plane/server/notification-push-bridge.ts
@@ -356,7 +356,8 @@ export class NotificationPushBridge {
   // suppresses — worst on the outbox retry path, which re-reads content long
   // after moderation acted. Returns the subset of `rows` that must NOT push.
   //
-  // Covers: bidirectional actor blocks, recipient->author mutes, recipient
+  // Covers: bidirectional actor blocks, recipient->author mutes (unscoped
+  // only — a scoped mute does not hide the notification), recipient
   // thread mutes on the subject's thread root, follows-only (`include:
   // 'follows'`) reason preferences, actor takedown / non-active upstream
   // status, and record-level takedowns (of the notif record and its subject).
@@ -414,7 +415,7 @@ export class NotificationPushBridge {
           .execute(),
         this.db.db
           .selectFrom('mute')
-          .select(['mutedByDid', 'subjectDid'])
+          .select(['mutedByDid', 'subjectDid', 'onlyReposts', 'onlyQuoteposts'])
           .where('mutedByDid', 'in', recipients)
           .where('subjectDid', 'in', authors)
           .execute(),
@@ -529,8 +530,14 @@ export class NotificationPushBridge {
       blockPairs.add(`${b.creator}:${b.subjectDid}`)
       blockPairs.add(`${b.subjectDid}:${b.creator}`)
     }
+    // A scoped mute ("only their reposts") is not a full mute: the appview
+    // treats the subject as muted only when no scope is set, so suppressing
+    // the push on mere row existence would hide notifications that
+    // listNotifications still shows. Mirrors getRelationships/getActorMutesActor.
     const mutePairs = new Set(
-      mutes.map((m) => `${m.mutedByDid}:${m.subjectDid}`),
+      mutes
+        .filter((m) => !m.onlyReposts && !m.onlyQuoteposts)
+        .map((m) => `${m.mutedByDid}:${m.subjectDid}`),
     )
     const takenDownActorDids = new Set(takenDownActors.map((a) => a.did))
     const takenDownRecordUris = new Set(takenDownRecords.map((r) => r.uri))

--- a/packages/bsky/tests/data-plane/notification-push-bridge.test.ts
+++ b/packages/bsky/tests/data-plane/notification-push-bridge.test.ts
@@ -618,15 +618,19 @@ describe('notification push bridge', () => {
       .execute()
   }
 
-  async function insertMute(mutedByDid: string, subjectDid: string) {
+  async function insertMute(
+    mutedByDid: string,
+    subjectDid: string,
+    scope: { onlyReposts?: boolean; onlyQuoteposts?: boolean } = {},
+  ) {
     await db.db
       .insertInto('mute')
       .values({
         subjectDid,
         mutedByDid,
         createdAt: new Date().toISOString(),
-        onlyReposts: false,
-        onlyQuoteposts: false,
+        onlyReposts: scope.onlyReposts ?? false,
+        onlyQuoteposts: scope.onlyQuoteposts ?? false,
       })
       .execute()
   }
@@ -688,6 +692,36 @@ describe('notification push bridge', () => {
     await bridge.flushOnceForTest([row.id])
 
     expect(pushNotifications).not.toHaveBeenCalled()
+  })
+
+  it('pushes when the recipient has only scoped the mute to reposts', async () => {
+    await insertCopyFixtures()
+    // a scoped mute restricts the mute to that content rather than muting the
+    // account, so listNotifications still shows the notification
+    await insertMute('did:plc:recipient', 'did:plc:actor', {
+      onlyReposts: true,
+    })
+    const row = await insertNotification()
+    const pushNotifications = vi.fn().mockResolvedValue({})
+    const bridge = createBridge(pushNotifications)
+
+    await bridge.flushOnceForTest([row.id])
+
+    expect(pushNotifications).toHaveBeenCalledTimes(1)
+  })
+
+  it('pushes when the recipient has only scoped the mute to quoteposts', async () => {
+    await insertCopyFixtures()
+    await insertMute('did:plc:recipient', 'did:plc:actor', {
+      onlyQuoteposts: true,
+    })
+    const row = await insertNotification()
+    const pushNotifications = vi.fn().mockResolvedValue({})
+    const bridge = createBridge(pushNotifications)
+
+    await bridge.flushOnceForTest([row.id])
+
+    expect(pushNotifications).toHaveBeenCalledTimes(1)
   })
 
   it('suppresses the push when the recipient has muted the thread', async () => {


### PR DESCRIPTION
The notification push bridge decides which notifications must not be pushed, mirroring the suppression `listNotifications` applies in-app. It treated any `mute` row for a (recipient, author) pair as a full mute, but a scoped mute (`onlyReposts` / `onlyQuoteposts`) restricts the mute to that content rather than muting the account — so a scoped mute silently suppressed every push notification from that account while `listNotifications` continued to show them. Suppression now applies only to unscoped mutes, matching `getRelationships` and `getActorMutesActor`.

Targets `merge/upstream-2026-08` rather than `main` 