### PR TITLE
feat(bsky): add permissioned space interaction views

### DIFF
--- a/lexicons/community/blacksky/feed/getSpacePostLikes.json
+++ b/lexicons/community/blacksky/feed/getSpacePostLikes.json
@@ -1,0 +1,51 @@
+{
+  "lexicon": 1,
+  "id": "community.blacksky.feed.getSpacePostLikes",
+  "description": "Get likes on a post in a permissioned space.",
+  "defs": {
+    "main": {
+      "type": "query",
+      "parameters": {
+        "type": "params",
+        "required": ["uri"],
+        "properties": {
+          "uri": {
+            "type": "string",
+            "description": "Permissioned-space record URI. Must be a seven-segment space record URI."
+          },
+          "cid": {
+            "type": "string",
+            "format": "cid",
+            "description": "CID of the subject record, if supplied."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 50
+          },
+          "cursor": { "type": "string" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["uri", "likes"],
+          "properties": {
+            "uri": { "type": "string" },
+            "cid": { "type": "string", "format": "cid" },
+            "cursor": { "type": "string" },
+            "likes": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "app.bsky.feed.getLikes#like"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/community/blacksky/feed/getSpacePostQuotes.json
+++ b/lexicons/community/blacksky/feed/getSpacePostQuotes.json
@@ -1,0 +1,51 @@
+{
+  "lexicon": 1,
+  "id": "community.blacksky.feed.getSpacePostQuotes",
+  "description": "Get quotes of a post in a permissioned space.",
+  "defs": {
+    "main": {
+      "type": "query",
+      "parameters": {
+        "type": "params",
+        "required": ["uri"],
+        "properties": {
+          "uri": {
+            "type": "string",
+            "description": "Permissioned-space record URI. Must be a seven-segment space record URI."
+          },
+          "cid": {
+            "type": "string",
+            "format": "cid",
+            "description": "CID of the subject record, if supplied."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 50
+          },
+          "cursor": { "type": "string" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["uri", "posts"],
+          "properties": {
+            "uri": { "type": "string" },
+            "cid": { "type": "string", "format": "cid" },
+            "cursor": { "type": "string" },
+            "posts": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "community.blacksky.feed.defs#spacePostView"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/bsky/proto/bsky.proto
+++ b/packages/bsky/proto/bsky.proto
@@ -331,6 +331,35 @@ message GetQuotesBySubjectSortedResponse {
   string cursor = 2;
 }
 
+message GetSpacePostLikesRequest {
+  RecordRef subject = 1;
+  int32 limit = 2;
+  string cursor = 3;
+}
+
+message SpaceLike {
+  string uri = 1;
+  string creator = 2;
+  string created_at = 3;
+  string indexed_at = 4;
+}
+
+message GetSpacePostLikesResponse {
+  repeated SpaceLike likes = 1;
+  string cursor = 2;
+}
+
+message GetSpacePostQuotesRequest {
+  RecordRef subject = 1;
+  int32 limit = 2;
+  string cursor = 3;
+}
+
+message GetSpacePostQuotesResponse {
+  repeated CommunityPostView posts = 1;
+  string cursor = 2;
+}
+
 // - return like uris for user A on subject B, C, D...
 //     - viewer state on posts
 message GetLikesByActorAndSubjectsRequest {
@@ -1667,6 +1696,7 @@ service Service {
   // Likes
   rpc GetLikesBySubject(GetLikesBySubjectRequest) returns (GetLikesBySubjectResponse);
   rpc GetLikesBySubjectSorted(GetLikesBySubjectSortedRequest) returns (GetLikesBySubjectSortedResponse);
+  rpc GetSpacePostLikes(GetSpacePostLikesRequest) returns (GetSpacePostLikesResponse);
   rpc GetLikesByActorAndSubjects(GetLikesByActorAndSubjectsRequest) returns (GetLikesByActorAndSubjectsResponse);
   rpc GetActorLikes(GetActorLikesRequest) returns (GetActorLikesResponse);
 
@@ -1677,6 +1707,7 @@ service Service {
 
   // Quotes
   rpc GetQuotesBySubjectSorted(GetQuotesBySubjectSortedRequest) returns (GetQuotesBySubjectSortedResponse);
+  rpc GetSpacePostQuotes(GetSpacePostQuotesRequest) returns (GetSpacePostQuotesResponse);
 
   // Interaction Counts
   rpc GetInteractionCounts(GetInteractionCountsRequest) returns (GetInteractionCountsResponse);

--- a/packages/bsky/src/api/community/blacksky/feed/getSpacePostLikes.ts
+++ b/packages/bsky/src/api/community/blacksky/feed/getSpacePostLikes.ts
@@ -1,0 +1,88 @@
+import {
+  AuthRequiredError,
+  InvalidRequestError,
+  type Server,
+} from '@atproto/xrpc-server'
+import { type DidString, normalizeDatetimeAlways } from '@atproto/syntax'
+import type { AppContext } from '../../../../context.js'
+import { community } from '../../../../lexicons/index.js'
+import {
+  isSpaceRecordUri,
+  parseSpaceRecordUri,
+  spaceUriOf,
+} from '../space-uri.js'
+import { canViewSpace } from '../tenant-gate.js'
+import { resHeaders } from '../../../util.js'
+
+export default function (server: Server, ctx: AppContext) {
+  server.add(community.blacksky.feed.getSpacePostLikes, {
+    auth: ctx.authVerifier.standard,
+    handler: async ({ params, auth, req }) => {
+      const viewer = auth.credentials.iss
+      const spaceRecord = parseSpaceRecordUri(params.uri)
+      if (!isSpaceRecordUri(params.uri) || !spaceRecord) {
+        throw new InvalidRequestError(
+          'URI is not a permissioned-space record',
+          'InvalidRequest',
+        )
+      }
+      if (!(await canViewSpace(ctx, spaceUriOf(spaceRecord), viewer))) {
+        throw new AuthRequiredError(
+          'Must have access to this space',
+          'MembershipRequired',
+        )
+      }
+
+      const result = await ctx.dataplane.getSpacePostLikes({
+        subject: { uri: params.uri, cid: params.cid },
+        limit: params.limit,
+        cursor: params.cursor,
+      })
+      const labelers = ctx.reqLabelers(req)
+      const hydrateCtx = await ctx.hydrator.createContext({
+        labelers,
+        viewer,
+      })
+      const likerDids = [
+        ...new Set(result.likes.map((like) => like.creator as DidString)),
+      ]
+      const [profileState, blocks] = await Promise.all([
+        ctx.hydrator.hydrateProfiles(likerDids, hydrateCtx),
+        ctx.hydrator.hydrateBidirectionalBlocks(
+          new Map([[spaceRecord.authorDid as DidString, likerDids]]),
+          hydrateCtx,
+        ),
+      ])
+      const authorDid = spaceRecord.authorDid as DidString
+      const likes = result.likes.flatMap((like) => {
+        const likerDid = like.creator as DidString
+        if (
+          blocks.get(authorDid)?.get(likerDid) ||
+          ctx.views.viewerBlockExists(likerDid, profileState)
+        ) {
+          return []
+        }
+        const actor = ctx.views.profile(likerDid, profileState)
+        if (!actor) return []
+        return [
+          {
+            actor,
+            createdAt: normalizeDatetimeAlways(like.createdAt),
+            indexedAt: normalizeDatetimeAlways(like.indexedAt),
+          },
+        ]
+      })
+
+      return {
+        encoding: 'application/json' as const,
+        body: {
+          uri: params.uri,
+          cid: params.cid,
+          cursor: result.cursor || undefined,
+          likes,
+        },
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
+      }
+    },
+  })
+}

--- a/packages/bsky/src/api/community/blacksky/feed/getSpacePostQuotes.ts
+++ b/packages/bsky/src/api/community/blacksky/feed/getSpacePostQuotes.ts
@@ -1,0 +1,81 @@
+import {
+  AuthRequiredError,
+  InvalidRequestError,
+  type Server,
+} from '@atproto/xrpc-server'
+import type { AppContext } from '../../../../context.js'
+import { community } from '../../../../lexicons/index.js'
+import { resHeaders } from '../../../util.js'
+import { isSpaceRecordUri, spaceOfRecordUri } from '../space-uri.js'
+import { canViewSpace } from '../tenant-gate.js'
+import {
+  buildCommunityPostView,
+  isBlockedForViewer,
+  isMutedForViewer,
+} from '../views/communityPostView.js'
+import { toSpacePostView } from '../views/spaceViews.js'
+
+export default function (server: Server, ctx: AppContext) {
+  server.add(community.blacksky.feed.getSpacePostQuotes, {
+    auth: ctx.authVerifier.standard,
+    handler: async ({ params, auth, req }) => {
+      const viewer = auth.credentials.iss
+      if (!isSpaceRecordUri(params.uri)) {
+        throw new InvalidRequestError(
+          'URI is not a permissioned-space record',
+          'InvalidRequest',
+        )
+      }
+      const spaceUri = spaceOfRecordUri(params.uri)
+      if (!spaceUri || !(await canViewSpace(ctx, spaceUri, viewer))) {
+        throw new AuthRequiredError(
+          'Must have access to this space',
+          'MembershipRequired',
+        )
+      }
+
+      const result = await ctx.dataplane.getSpacePostQuotes({
+        subject: { uri: params.uri, cid: params.cid },
+        limit: params.limit,
+        cursor: params.cursor,
+      })
+      const labelers = ctx.reqLabelers(req)
+      const hydrateCtx = await ctx.hydrator.createContext({
+        labelers,
+        viewer,
+      })
+      const preAuthorized = new Set([spaceUri])
+      const posts = (
+        await Promise.all(
+          result.posts.map(async (row) => {
+            if (row.spaceUri !== spaceUri) return null
+            const post = await buildCommunityPostView(
+              ctx as any,
+              hydrateCtx,
+              row as any,
+              0,
+              viewer,
+              undefined,
+              preAuthorized,
+            )
+            if (!post || isBlockedForViewer(post) || isMutedForViewer(post)) {
+              return null
+            }
+            return toSpacePostView(post)
+          }),
+        )
+      ).filter(Boolean)
+
+      return {
+        encoding: 'application/json' as const,
+        body: {
+          uri: params.uri,
+          cid: params.cid,
+          cursor: result.cursor || undefined,
+          posts,
+        } as any,
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
+      }
+    },
+  })
+}

--- a/packages/bsky/src/api/index.ts
+++ b/packages/bsky/src/api/index.ts
@@ -111,6 +111,8 @@ import getCommunityThread from './community/blacksky/feed/getCommunityThread.js'
 import getSpaceFeed from './community/blacksky/feed/getSpaceFeed.js'
 import setThreadMute from './community/blacksky/feed/setThreadMute.js'
 import getCommunityTimeline from './community/blacksky/feed/getCommunityTimeline.js'
+import getSpacePostLikes from './community/blacksky/feed/getSpacePostLikes.js'
+import getSpacePostQuotes from './community/blacksky/feed/getSpacePostQuotes.js'
 import submitCommunityPost from './community/blacksky/feed/submitPost.js'
 import applyPeerModLabel from './community/blacksky/moderation/applyLabel.js'
 import getMyPeerModLabels from './community/blacksky/moderation/getMyLabels.js'
@@ -240,6 +242,8 @@ export default function (server: Server, ctx: AppContext) {
   getSpaceFeed(server, ctx)
   setThreadMute(server, ctx)
   getCommunityTimeline(server, ctx)
+  getSpacePostLikes(server, ctx)
+  getSpacePostQuotes(server, ctx)
   submitCommunityPost(server, ctx)
   applyPeerModLabel(server, ctx)
   removePeerModLabel(server, ctx)

--- a/packages/bsky/src/data-plane/server/routes/community.ts
+++ b/packages/bsky/src/data-plane/server/routes/community.ts
@@ -7,6 +7,7 @@ import { AtUri } from '@atproto/syntax'
 import type { Service } from '../../../proto/bsky_connect.js'
 import type { Database } from '../db/index.js'
 import {
+  isSpaceRecordUri,
   spaceOfRecordUri,
   spaceRecordAuthor,
 } from '../../../api/community/blacksky/space-uri.js'
@@ -678,6 +679,48 @@ export default (
       return {
         posts: rows.map(communityPostFromRow),
         cursor: nextCursor,
+      }
+    },
+
+    async getSpacePostQuotes(req) {
+      const { subject, limit, cursor } = req
+      const space = subject?.uri ? spaceOfRecordUri(subject.uri) : null
+      if (!subject?.uri || !isSpaceRecordUri(subject.uri) || !space) {
+        return { posts: [] }
+      }
+
+      const params: unknown[] = [subject.uri, space, limit + 1]
+      let query = `SELECT * FROM community_post
+        WHERE (embed->'record'->>'uri' = $1
+           OR embed->'record'->'record'->>'uri' = $1)
+          AND ${UNFLAGGED}
+          AND space_uri = $2`
+      if (subject.cid) {
+        const cidParameter = params.push(subject.cid)
+        query += ` AND (embed->'record'->>'cid' = $${cidParameter}
+           OR embed->'record'->'record'->>'cid' = $${cidParameter})`
+      }
+      const keyset = parseKeysetCursor(cursor)
+      if (cursor && !keyset) {
+        throw new Error('invalid cursor')
+      }
+      if (keyset) {
+        const sortAtParameter = params.push(keyset.sortAt)
+        const cidParameter = params.push(keyset.cid)
+        query += ` AND ("sortAt", cid) < ($${sortAtParameter}, $${cidParameter})`
+      }
+      query += ` ORDER BY "sortAt" DESC, cid DESC LIMIT $3`
+
+      const res = await db.pool.query(query, params)
+      const rows = res.rows
+      if (rows.length <= limit) {
+        return { posts: rows.map(communityPostFromRow) }
+      }
+      rows.pop()
+      const last = rows.at(-1)
+      return {
+        posts: rows.map(communityPostFromRow),
+        cursor: last ? `${last.sortAt}::${last.cid}` : '',
       }
     },
 

--- a/packages/bsky/src/data-plane/server/routes/likes.ts
+++ b/packages/bsky/src/data-plane/server/routes/likes.ts
@@ -4,6 +4,10 @@ import { keyBy } from '@atproto/common'
 import type { Service } from '../../../proto/bsky_connect.js'
 import type { Database } from '../db/index.js'
 import { TimeCidKeyset, paginate } from '../db/pagination.js'
+import {
+  isSpaceRecordUri,
+  spaceOfRecordUri,
+} from '../../../api/community/blacksky/space-uri.js'
 
 export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
   async getLikesBySubjectSorted(req) {
@@ -32,6 +36,45 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
 
     return {
       uris: likes.map((l) => l.uri),
+      cursor: keyset.packFromResult(likes),
+    }
+  },
+
+  async getSpacePostLikes(req) {
+    const { subject, cursor, limit } = req
+    const spaceUri = subject?.uri ? spaceOfRecordUri(subject.uri) : null
+    if (!subject?.uri || !isSpaceRecordUri(subject.uri) || !spaceUri) {
+      return { likes: [] }
+    }
+
+    const { ref } = db.db.dynamic
+    let builder = db.db
+      .selectFrom('like')
+      .where('like.subject', '=', subject.uri)
+      .where('like.space_uri', '=', spaceUri)
+      .select([
+        'like.uri',
+        'like.creator',
+        'like.createdAt',
+        'like.indexedAt',
+        'like.sortAt',
+        'like.cid',
+      ])
+    if (subject.cid) {
+      builder = builder.where('like.subjectCid', '=', subject.cid)
+    }
+
+    const keyset = new TimeCidKeyset(ref('like.sortAt'), ref('like.cid'))
+    builder = paginate(builder, { limit, cursor, keyset })
+    const likes = await builder.execute()
+
+    return {
+      likes: likes.map((like) => ({
+        uri: like.uri,
+        creator: like.creator,
+        createdAt: like.createdAt,
+        indexedAt: like.indexedAt,
+      })),
       cursor: keyset.packFromResult(likes),
     }
   },

--- a/packages/bsky/tests/community/space-post-interactions.test.ts
+++ b/packages/bsky/tests/community/space-post-interactions.test.ts
@@ -1,0 +1,366 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import getLikes from '../../src/api/app/bsky/feed/getLikes.js'
+import getQuotes from '../../src/api/app/bsky/feed/getQuotes.js'
+import getSpacePostLikes from '../../src/api/community/blacksky/feed/getSpacePostLikes.js'
+import getSpacePostQuotes from '../../src/api/community/blacksky/feed/getSpacePostQuotes.js'
+import * as GetSpacePostLikes from '../../src/lexicons/community/blacksky/feed/getSpacePostLikes.defs.js'
+import * as GetSpacePostQuotes from '../../src/lexicons/community/blacksky/feed/getSpacePostQuotes.defs.js'
+import * as CommunityFeedDefs from '../../src/lexicons/community/blacksky/feed/defs.defs.js'
+import { clearTenantGateCaches } from '../../src/api/community/blacksky/tenant-gate.js'
+import { resetSpaceCredentials } from '../../src/api/community/blacksky/space-credential.js'
+
+const SPACE = 'at://did:plc:tenant/space/community.blacksky.feed/private'
+const OTHER_SPACE = 'at://did:plc:tenant/space/community.blacksky.feed/other'
+const POST = `${SPACE}/did:plc:alice/app.bsky.feed.post/root`
+const LEGACY_POST = 'at://did:plc:alice/community.blacksky.feed.post/legacy'
+const VIEWER = 'did:plc:viewer'
+const MANAGING_APP_DID = 'did:web:feeds.example.com'
+const CID = 'bafyreiacsg6vsw7ppwbnowzsdgstulhrwftirtcnvkcbnfgvhwjrnzfmsu'
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+
+const allowSpace = (allowed: boolean) => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: URL | string) => {
+      const url = String(input)
+      if (url.includes('/admin/mintCredential')) {
+        const payload = Buffer.from(
+          JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 7200 }),
+        ).toString('base64url')
+        return json({ credential: `hdr.${payload}.sig` })
+      }
+      if (url.includes('com.atproto.space.getSpace')) {
+        return json({
+          config: { managingApp: `${MANAGING_APP_DID}#bsky_fg` },
+        })
+      }
+      if (url.includes('community.blacksky.space.checkAccess')) {
+        return json({ allowed })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }),
+  )
+}
+
+const makeCtx = (dataplane: Record<string, unknown>) => ({
+  cfg: { serverDid: 'did:web:appview.test' },
+  signingKey: {
+    did: () => 'did:key:zQ3s',
+    jwtAlg: 'ES256K',
+    sign: async () => new Uint8Array(64),
+  },
+  idResolver: {
+    did: {
+      resolve: async (did: string) => ({
+        id: did,
+        service: [
+          {
+            id: `#${did === 'did:plc:tenant' ? 'atproto_pds' : 'bsky_fg'}`,
+            type: 'x',
+            serviceEndpoint:
+              did === 'did:plc:tenant'
+                ? 'https://pds.example.com'
+                : 'https://feeds.example.com',
+          },
+        ],
+      }),
+    },
+  },
+  reqLabelers: () => ({ dids: [], redact: new Set<string>() }),
+  hydrator: {
+    createContext: async (value: unknown) => value,
+    hydrateProfiles: vi.fn(async () => ({})),
+    hydrateBidirectionalBlocks: vi.fn(async () => new Map()),
+    hydrateProfilesBasic: vi.fn(async () => ({})),
+    label: {
+      getLabelsForSubjects: vi.fn(async () => ({ getBySubject: () => [] })),
+    },
+  },
+  views: {
+    profile: (did: string) => ({
+      did,
+      handle: `${did.split(':').at(-1)}.test`,
+    }),
+    viewerBlockExists: () => false,
+    profileBasic: (did: string) => ({
+      did,
+      handle: `${did.split(':').at(-1)}.test`,
+      labels: [],
+    }),
+    imgUriBuilder: { getPresetUri: () => '' },
+    videoUriBuilder: { playlist: () => '', thumbnail: () => '' },
+  },
+  dataplane,
+  authVerifier: { standard: {} },
+})
+
+const register = (route: any, ctx: any) => {
+  let config: any
+  route(
+    { add: (_lex: unknown, value: unknown) => (config = value) } as any,
+    ctx,
+  )
+  return config.handler
+}
+
+const request = (handler: any, params: Record<string, unknown>) =>
+  handler({
+    params,
+    auth: { credentials: { iss: VIEWER } },
+    req: { headers: {} },
+  })
+
+describe('space post likes and quotes', () => {
+  beforeEach(() => {
+    clearTenantGateCaches()
+    resetSpaceCredentials()
+    vi.stubEnv('COMMUNITY_SPACE_MINT_TOKEN', 'test-mint-token')
+    vi.unstubAllGlobals()
+  })
+
+  it('validates custom output shapes and keeps space URIs out of standard views', () => {
+    const like = {
+      actor: { did: 'did:plc:bob', handle: 'bob.test' },
+      createdAt: '2026-08-18T00:00:00.000Z',
+      indexedAt: '2026-08-18T00:00:01.000Z',
+    }
+    expect(
+      GetSpacePostLikes.$output.schema?.safeParse({
+        uri: POST,
+        likes: [like],
+      }).success,
+    ).toBe(true)
+    expect(
+      GetSpacePostQuotes.$output.schema?.safeParse({
+        uri: POST,
+        posts: [],
+      }).success,
+    ).toBe(true)
+    expect(
+      CommunityFeedDefs.spacePostView.safeParse({
+        $type: 'community.blacksky.feed.defs#spacePostView',
+        uri: POST,
+        cid: CID,
+        author: { did: 'did:plc:bob', handle: 'bob.test' },
+        record: { text: 'private' },
+        indexedAt: '2026-08-18T00:00:00.000Z',
+      }).success,
+    ).toBe(true)
+  })
+
+  it('rejects non-space URIs before data-plane access', async () => {
+    const getSpacePostLikesCall = vi.fn()
+    const ctx = makeCtx({ getSpacePostLikes: getSpacePostLikesCall })
+    const handler = register(getSpacePostLikes, ctx)
+
+    await expect(
+      request(handler, { uri: LEGACY_POST, limit: 10 }),
+    ).rejects.toMatchObject({
+      customErrorName: 'InvalidRequest',
+    })
+    expect(getSpacePostLikesCall).not.toHaveBeenCalled()
+  })
+
+  it('authorizes before data-plane access and returns actor timestamps', async () => {
+    allowSpace(true)
+    const getSpacePostLikesCall = vi.fn(async () => ({
+      likes: [
+        {
+          uri: `${SPACE}/did:plc:bob/app.bsky.feed.like/one`,
+          creator: 'did:plc:bob',
+          createdAt: '2026-08-18T00:00:00.000Z',
+          indexedAt: '2026-08-18T00:00:02.000Z',
+        },
+      ],
+      cursor: '',
+    }))
+    const ctx = makeCtx({ getSpacePostLikes: getSpacePostLikesCall })
+    const handler = register(getSpacePostLikes, ctx)
+
+    const result = await request(handler, { uri: POST, limit: 10 })
+    expect(getSpacePostLikesCall).toHaveBeenCalledWith({
+      subject: { uri: POST, cid: undefined },
+      limit: 10,
+      cursor: undefined,
+    })
+    expect(result.body.likes).toEqual([
+      {
+        actor: { did: 'did:plc:bob', handle: 'bob.test' },
+        createdAt: '2026-08-18T00:00:00.000Z',
+        indexedAt: '2026-08-18T00:00:02.000Z',
+      },
+    ])
+  })
+
+  it('does not call the likes data plane for an unauthorized viewer', async () => {
+    allowSpace(false)
+    const getSpacePostLikesCall = vi.fn()
+    const ctx = makeCtx({ getSpacePostLikes: getSpacePostLikesCall })
+    const handler = register(getSpacePostLikes, ctx)
+
+    await expect(request(handler, { uri: POST })).rejects.toMatchObject({
+      customErrorName: 'MembershipRequired',
+    })
+    expect(getSpacePostLikesCall).not.toHaveBeenCalled()
+  })
+
+  it('omits likes by actors blocked by the post author or viewer', async () => {
+    allowSpace(true)
+    const ctx = makeCtx({
+      getSpacePostLikes: vi.fn(async () => ({
+        likes: [
+          {
+            uri: 'like-bob',
+            creator: 'did:plc:bob',
+            createdAt: '2026-08-18T00:00:00Z',
+            indexedAt: '2026-08-18T00:00:00Z',
+          },
+          {
+            uri: 'like-carol',
+            creator: 'did:plc:carol',
+            createdAt: '2026-08-18T00:00:01Z',
+            indexedAt: '2026-08-18T00:00:01Z',
+          },
+        ],
+        cursor: '',
+      })),
+    })
+    ctx.hydrator.hydrateBidirectionalBlocks = vi.fn(
+      async () =>
+        new Map([['did:plc:alice', new Map([['did:plc:bob', true]])]]),
+    )
+    ;(ctx as any).views.viewerBlockExists = (did: string) =>
+      did === 'did:plc:carol'
+    const handler = register(getSpacePostLikes, ctx)
+
+    await expect(request(handler, { uri: POST })).resolves.toMatchObject({
+      body: { likes: [] },
+    })
+  })
+
+  it('returns only same-space quotes as custom post views and applies block/mute filters', async () => {
+    allowSpace(true)
+    const sameSpace = (creator: string, rkey: string) => ({
+      uri: `${SPACE}/${creator}/app.bsky.feed.post/${rkey}`,
+      cid: CID,
+      creator,
+      text: 'quoted',
+      createdAt: '2026-08-18T00:00:00.000Z',
+      indexedAt: '2026-08-18T00:00:00.000Z',
+      spaceUri: SPACE,
+    })
+    const getSpacePostQuotesCall = vi.fn(async () => ({
+      posts: [
+        sameSpace('did:plc:bob', 'allowed'),
+        { ...sameSpace('did:plc:carol', 'other-space'), spaceUri: OTHER_SPACE },
+        sameSpace('did:plc:carol', 'blocked'),
+        sameSpace('did:plc:dan', 'muted'),
+      ],
+      cursor: '',
+    }))
+    const ctx = makeCtx({ getSpacePostQuotes: getSpacePostQuotesCall })
+    ctx.views.profileBasic = (did: string) => ({
+      did,
+      handle: `${did.split(':').at(-1)}.test`,
+      labels: [],
+      ...(did === 'did:plc:carol' ? { viewer: { blocking: 'block' } } : {}),
+      ...(did === 'did:plc:dan' ? { viewer: { muted: true } } : {}),
+    })
+    ctx.dataplane.getCommunityPostReplyCount = vi.fn(async () => ({ count: 0 }))
+    ctx.dataplane.getCommunityPostLikeCount = vi.fn(async () => ({ count: 0 }))
+    ctx.dataplane.getCommunityPostQuoteCount = vi.fn(async () => ({ count: 0 }))
+    ctx.dataplane.getCommunityPostViewerLike = vi.fn(async () => ({
+      likeUri: '',
+    }))
+    const handler = register(getSpacePostQuotes as any, ctx)
+
+    const result = await request(handler, { uri: POST })
+    expect(getSpacePostQuotesCall).toHaveBeenCalledOnce()
+    expect(result.body.posts).toHaveLength(1)
+    expect(result.body.posts[0].$type).toBe(
+      'community.blacksky.feed.defs#spacePostView',
+    )
+    expect(
+      GetSpacePostQuotes.$output.schema?.safeParse(result.body).success,
+    ).toBe(true)
+  })
+
+  it('does not call the quotes data plane for an unauthorized viewer', async () => {
+    allowSpace(false)
+    const getSpacePostQuotesCall = vi.fn()
+    const ctx = makeCtx({ getSpacePostQuotes: getSpacePostQuotesCall })
+    const handler = register(getSpacePostQuotes as any, ctx)
+
+    await expect(request(handler, { uri: POST })).rejects.toMatchObject({
+      customErrorName: 'MembershipRequired',
+    })
+    expect(getSpacePostQuotesCall).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-space quote URIs before data-plane access', async () => {
+    const getSpacePostQuotesCall = vi.fn()
+    const ctx = makeCtx({ getSpacePostQuotes: getSpacePostQuotesCall })
+    const handler = register(getSpacePostQuotes as any, ctx)
+
+    await expect(request(handler, { uri: LEGACY_POST })).rejects.toMatchObject({
+      customErrorName: 'InvalidRequest',
+    })
+    expect(getSpacePostQuotesCall).not.toHaveBeenCalled()
+  })
+
+  it('keeps standard likes and quotes on their legacy community routes', async () => {
+    const legacyLikeUri =
+      'at://did:plc:bob/app.bsky.feed.like/legacy-community-like'
+    const legacyQuotes = vi.fn(async () => ({ posts: [], cursor: '' }))
+    const legacyLikes = vi.fn(async () => ({
+      uris: [legacyLikeUri],
+      cursor: '',
+    }))
+    const ctx = makeCtx({
+      checkCommunityMembership: vi.fn(async () => ({ isMember: true })),
+      getCommunityPostQuotes: legacyQuotes,
+    }) as any
+    ctx.authVerifier.parseCreds = () => ({
+      viewer: VIEWER,
+      includeTakedowns: false,
+      skipViewerBlocks: false,
+    })
+    ctx.hydrator.dataplane = { getLikesBySubjectSorted: legacyLikes }
+    ctx.hydrator.hydrateLikes = vi.fn(async () => ({
+      likes: new Map([
+        [
+          legacyLikeUri,
+          {
+            record: { createdAt: '2026-08-18T00:00:00.000Z' },
+            sortedAt: new Date('2026-08-18T00:00:01.000Z'),
+          },
+        ],
+      ]),
+    }))
+
+    const likesResult = await request(register(getLikes, ctx), {
+      uri: LEGACY_POST,
+    })
+    const quotesResult = await request(register(getQuotes, ctx), {
+      uri: LEGACY_POST,
+    })
+
+    expect(likesResult.body.likes[0].actor.did).toBe('did:plc:bob')
+    expect(legacyLikes).toHaveBeenCalledWith({
+      subject: { uri: LEGACY_POST, cid: undefined },
+      cursor: undefined,
+      limit: undefined,
+    })
+    expect(quotesResult.body.posts).toEqual([])
+    expect(legacyQuotes).toHaveBeenCalledWith({
+      uri: LEGACY_POST,
+      limit: undefined,
+      cursor: undefined,
+    })
+  })
+})

--- a/packages/bsky/tests/data-plane/community-posts.test.ts
+++ b/packages/bsky/tests/data-plane/community-posts.test.ts
@@ -38,12 +38,17 @@ describe('community post tenant discriminator', () => {
     await network?.close()
   })
 
-  const insertPost = async (uri: string, spaceUri: string | null) => {
+  const insertPost = async (
+    uri: string,
+    spaceUri: string | null,
+    timestamp = new Date().toISOString(),
+    cid = 'bafytest',
+  ) => {
     await db.pool.query(
       `INSERT INTO community_post
         (uri, cid, rkey, creator, text, "createdAt", "indexedAt", space_uri)
-       VALUES ($1, 'bafytest', $2::varchar, 'did:plc:alice', $2::text, $3, $3, $4)`,
-      [uri, uri.split('/').at(-1), new Date().toISOString(), spaceUri],
+       VALUES ($1, $2, $3::varchar, 'did:plc:alice', $3::text, $4, $4, $5)`,
+      [uri, cid, uri.split('/').at(-1), timestamp, spaceUri],
     )
   }
 
@@ -401,6 +406,171 @@ describe('community post tenant discriminator', () => {
         cursor: '',
       }),
     ).resolves.toMatchObject({ uris: [] })
+  })
+
+  it('reads space likes with exact-space filtering and a stable tie-breaker', async () => {
+    const subject =
+      'at://did:plc:tenant/space/community.blacksky.feed/private/did:plc:alice/app.bsky.feed.post/root'
+    const spaceUri = 'at://did:plc:tenant/space/community.blacksky.feed/private'
+    const otherSpaceUri =
+      'at://did:plc:tenant/space/community.blacksky.feed/other'
+    const timestamp = '2026-08-18T00:00:00.000Z'
+    const route = likeRoutes(db) as any
+
+    const insertLike = async (
+      rkey: string,
+      rowSpaceUri: string | null,
+      creator: string,
+    ) => {
+      await db.pool.query(
+        `INSERT INTO "like"
+          (uri, cid, creator, subject, "subjectCid", "createdAt", "indexedAt", space_uri)
+         VALUES ($1, $2, $3, $4, 'bafysubject', $5, $5, $6)`,
+        [
+          `${rowSpaceUri ?? 'at://did:plc:public/app.bsky.feed.like'}/${rkey}`,
+          `bafylike${rkey}`,
+          creator,
+          subject,
+          timestamp,
+          rowSpaceUri,
+        ],
+      )
+    }
+
+    await insertLike('one', spaceUri, 'did:plc:bob')
+    await insertLike('two', spaceUri, 'did:plc:carol')
+    await insertLike('other', otherSpaceUri, 'did:plc:dan')
+    await insertLike('public', null, 'did:plc:eve')
+
+    const first = await route.getSpacePostLikes({
+      subject: { uri: subject },
+      limit: 1,
+      cursor: '',
+    })
+    const second = await route.getSpacePostLikes({
+      subject: { uri: subject },
+      limit: 1,
+      cursor: first.cursor,
+    })
+    const third = await route.getSpacePostLikes({
+      subject: { uri: subject },
+      limit: 1,
+      cursor: second.cursor,
+    })
+    expect(first.likes).toHaveLength(1)
+    expect(second.likes).toHaveLength(1)
+    expect(third.likes).toHaveLength(0)
+    expect(
+      [...first.likes, ...second.likes, ...third.likes].map(
+        (like: any) => like.creator,
+      ),
+    ).toEqual(expect.arrayContaining(['did:plc:bob', 'did:plc:carol']))
+    expect(
+      [...first.likes, ...second.likes, ...third.likes].map(
+        (like: any) => like.creator,
+      ),
+    ).not.toEqual(expect.arrayContaining(['did:plc:dan', 'did:plc:eve']))
+  })
+
+  it('reads space quotes with exact-space filtering and stable pagination', async () => {
+    const subject =
+      'at://did:plc:tenant/space/community.blacksky.feed/private/did:plc:alice/app.bsky.feed.post/root'
+    const spaceUri = 'at://did:plc:tenant/space/community.blacksky.feed/private'
+    const otherSpaceUri =
+      'at://did:plc:tenant/space/community.blacksky.feed/other'
+    const timestamp = '2026-08-18T00:00:00.000Z'
+    const route = communityRoutes(db, undefined) as any
+    const quoteRows = [
+      ['one', spaceUri],
+      ['two', spaceUri],
+      ['other', otherSpaceUri],
+      ['public', null],
+    ] as const
+
+    for (const [rkey, rowSpaceUri] of quoteRows) {
+      const uri = rowSpaceUri
+        ? `${rowSpaceUri}/did:plc:quoting/app.bsky.feed.post/${rkey}`
+        : `at://did:plc:quoting/community.blacksky.feed.post/${rkey}`
+      await insertPost(uri, rowSpaceUri, timestamp, `bafyquote${rkey}`)
+      await db.pool.query(
+        `UPDATE community_post SET embed = $1::jsonb WHERE uri = $2`,
+        [JSON.stringify({ record: { uri: subject, cid: 'bafysubject' } }), uri],
+      )
+    }
+
+    const first = await route.getSpacePostQuotes({
+      subject: { uri: subject },
+      limit: 1,
+      cursor: '',
+    })
+    const second = await route.getSpacePostQuotes({
+      subject: { uri: subject },
+      limit: 1,
+      cursor: first.cursor,
+    })
+    expect(first.posts).toHaveLength(1)
+    expect(second.posts).toHaveLength(1)
+    expect(second.cursor).toBeUndefined()
+    expect(
+      [...first.posts, ...second.posts].map((post: any) => post.spaceUri),
+    ).toEqual([spaceUri, spaceUri])
+  })
+
+  it('keeps legacy readers on their existing public-only behavior', async () => {
+    const legacySubject =
+      'at://did:plc:alice/community.blacksky.feed.post/legacy-subject'
+    const spaceUri = 'at://did:plc:tenant/space/community.blacksky.feed/private'
+    const routes = communityRoutes(db, undefined) as any
+    const likes = likeRoutes(db) as any
+
+    await db.pool.query(
+      `INSERT INTO "like"
+        (uri, cid, creator, subject, "subjectCid", "createdAt", "indexedAt", space_uri)
+       VALUES
+        ('at://did:plc:bob/app.bsky.feed.like/public', 'bafypublic', 'did:plc:bob', $1, 'bafysubject', now()::text, now()::text, NULL),
+        ('${spaceUri}/did:plc:carol/app.bsky.feed.like/private', 'bafyprivate', 'did:plc:carol', $1, 'bafysubject', now()::text, now()::text, '${spaceUri}')`,
+      [legacySubject],
+    )
+    await insertPost(
+      'at://did:plc:quoting/community.blacksky.feed.post/public-quote',
+      null,
+    )
+    await insertPost(
+      `${spaceUri}/did:plc:quoting/app.bsky.feed.post/private-quote`,
+      spaceUri,
+    )
+    await db.pool.query(
+      `UPDATE community_post SET embed = $1::jsonb
+       WHERE uri IN ($2, $3)`,
+      [
+        JSON.stringify({ record: { uri: legacySubject } }),
+        'at://did:plc:quoting/community.blacksky.feed.post/public-quote',
+        `${spaceUri}/did:plc:quoting/app.bsky.feed.post/private-quote`,
+      ],
+    )
+
+    await expect(
+      likes.getLikesBySubjectSorted({
+        subject: { uri: legacySubject },
+        limit: 10,
+        cursor: '',
+      }),
+    ).resolves.toMatchObject({
+      uris: ['at://did:plc:bob/app.bsky.feed.like/public'],
+    })
+    await expect(
+      routes.getCommunityPostQuotes({
+        uri: legacySubject,
+        limit: 10,
+        cursor: '',
+      }),
+    ).resolves.toMatchObject({
+      posts: [
+        {
+          uri: 'at://did:plc:quoting/community.blacksky.feed.post/public-quote',
+        },
+      ],
+    })
   })
 
   it('writes projected notifications only for allowed recipients', async () => {


### PR DESCRIPTION
## Summary

- add permission-aware `getSpacePostLikes` and `getSpacePostQuotes` XRPC queries
- constrain data-plane reads to the exact permissioned space with stable pagination
- preserve existing public and legacy community-only likes/quotes paths unchanged
- apply space authorization, actor hydration, and block/mute filtering before returning results

## Validation

- new AppView route tests: 9 passed
- wrapped community-post data-plane suite: 21 passed
- existing public likes/quotes suites: 13 passed
- lexicon and protobuf code generation passed
- package build and test typechecks passed
- Prettier and `git diff --check` passed

Locally exercised end to end against the permissioned-feed stack, including opening the liked-by page for a private space post.
