### PR TITLE
feat(bsky): add private space notification queries

### DIFF
--- a/.changeset/tender-spaces-notify.md
+++ b/.changeset/tender-spaces-notify.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': minor
+---
+
+Add private-space-aware notification list and unread-count queries while keeping standard notification queries public-only.

--- a/lexicons/community/blacksky/notification/getUnreadCount.json
+++ b/lexicons/community/blacksky/notification/getUnreadCount.json
@@ -1,0 +1,27 @@
+{
+  "lexicon": 1,
+  "id": "community.blacksky.notification.getUnreadCount",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Count unread public and authorized permissioned-space notifications for the requesting account.",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "priority": { "type": "boolean" },
+          "seenAt": { "type": "string", "format": "datetime" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["count"],
+          "properties": {
+            "count": { "type": "integer" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/community/blacksky/notification/listNotifications.json
+++ b/lexicons/community/blacksky/notification/listNotifications.json
@@ -1,0 +1,103 @@
+{
+  "lexicon": 1,
+  "id": "community.blacksky.notification.listNotifications",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Enumerate public and authorized permissioned-space notifications for the requesting account. An empty page may include a cursor and should be continued.",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "reasons": {
+            "description": "Notification reasons to include in response.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "A reason that matches the reason property of #notification."
+            }
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 50
+          },
+          "priority": { "type": "boolean" },
+          "cursor": { "type": "string" },
+          "seenAt": { "type": "string", "format": "datetime" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["notifications"],
+          "properties": {
+            "cursor": { "type": "string" },
+            "notifications": {
+              "type": "array",
+              "items": { "type": "ref", "ref": "#notification" }
+            },
+            "priority": { "type": "boolean" },
+            "seenAt": { "type": "string", "format": "datetime" }
+          }
+        }
+      }
+    },
+    "notification": {
+      "type": "object",
+      "required": [
+        "uri",
+        "cid",
+        "author",
+        "reason",
+        "record",
+        "isRead",
+        "indexedAt"
+      ],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "description": "The public AT URI or permissioned-space record URI that caused the notification."
+        },
+        "cid": { "type": "string", "format": "cid" },
+        "author": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" },
+        "reason": {
+          "type": "string",
+          "description": "The reason why this notification was delivered.",
+          "knownValues": [
+            "like",
+            "repost",
+            "follow",
+            "mention",
+            "reply",
+            "quote",
+            "starterpack-joined",
+            "verified",
+            "unverified",
+            "like-via-repost",
+            "repost-via-repost",
+            "subscribed-post",
+            "contact-match"
+          ]
+        },
+        "reasonSubject": {
+          "type": "string",
+          "description": "The public AT URI or permissioned-space record URI that is the notification subject."
+        },
+        "record": { "type": "unknown" },
+        "starterPack": {
+          "description": "The starter pack associated with this notification.",
+          "type": "ref",
+          "ref": "app.bsky.graph.defs#starterPackViewBasic"
+        },
+        "isRead": { "type": "boolean" },
+        "indexedAt": { "type": "string", "format": "datetime" },
+        "labels": {
+          "type": "array",
+          "items": { "type": "ref", "ref": "com.atproto.label.defs#label" }
+        }
+      }
+    }
+  }
+}

--- a/packages/bsky/proto/bsky.proto
+++ b/packages/bsky/proto/bsky.proto
@@ -898,6 +898,7 @@ message GetNotificationsRequest {
   int32 limit = 2;
   string cursor = 3;
   bool priority = 4;
+  bool include_space_notifications = 5;
 }
 
 message Notification {

--- a/packages/bsky/src/api/app/bsky/notification/domain.test.ts
+++ b/packages/bsky/src/api/app/bsky/notification/domain.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'vitest'
+import { classifyNotificationDomain } from './domain.js'
+
+const publicPost = 'at://did:plc:alice/app.bsky.feed.post/3kpublic'
+const firstSpace = 'at://did:plc:tenant/space/community.blacksky.feed/first'
+const secondSpace = 'at://did:plc:tenant/space/community.blacksky.feed/second'
+const firstPost = `${firstSpace}/did:plc:alice/app.bsky.feed.post/3kfirst`
+const secondPost = `${secondSpace}/did:plc:alice/app.bsky.feed.post/3ksecond`
+
+describe(classifyNotificationDomain, () => {
+  test.each([
+    {
+      note: 'public record without subject',
+      notification: { uri: publicPost },
+      expected: { type: 'public' },
+    },
+    {
+      note: 'public record with public subject',
+      notification: { uri: publicPost, reasonSubject: publicPost },
+      expected: { type: 'public' },
+    },
+    {
+      note: 'space record without subject',
+      notification: { uri: firstPost },
+      expected: { type: 'space', spaceUri: firstSpace },
+    },
+    {
+      note: 'space record with same-space subject',
+      notification: { uri: firstPost, reasonSubject: firstPost },
+      expected: { type: 'space', spaceUri: firstSpace },
+    },
+    {
+      note: 'public record with private subject',
+      notification: { uri: publicPost, reasonSubject: firstPost },
+      expected: { type: 'invalid' },
+    },
+    {
+      note: 'private record with public subject',
+      notification: { uri: firstPost, reasonSubject: publicPost },
+      expected: { type: 'invalid' },
+    },
+    {
+      note: 'cross-space pair',
+      notification: { uri: firstPost, reasonSubject: secondPost },
+      expected: { type: 'invalid' },
+    },
+    {
+      note: 'malformed space record',
+      notification: {
+        uri: 'at://did:plc:tenant/space/community.blacksky.feed/first/broken',
+      },
+      expected: { type: 'invalid' },
+    },
+    {
+      note: 'malformed ordinary uri',
+      notification: { uri: 'not-a-uri' },
+      expected: { type: 'invalid' },
+    },
+  ])('$note', ({ notification, expected }) => {
+    expect(classifyNotificationDomain(notification)).toEqual(expected)
+  })
+})

--- a/packages/bsky/src/api/app/bsky/notification/domain.ts
+++ b/packages/bsky/src/api/app/bsky/notification/domain.ts
@@ -1,0 +1,44 @@
+import { isAtUriString } from '@atproto/syntax'
+import {
+  parseSpaceRecordUri,
+  spaceUriOf,
+} from '../../../community/blacksky/space-uri.js'
+
+export type NotificationDomain =
+  { type: 'public' } | { type: 'space'; spaceUri: string } | { type: 'invalid' }
+
+const uriDomain = (
+  uri: string | null | undefined,
+):
+  | { type: 'public' }
+  | { type: 'space'; spaceUri: string }
+  | { type: 'invalid' } => {
+  if (!uri) return { type: 'invalid' }
+  const space = parseSpaceRecordUri(uri)
+  if (space) return { type: 'space', spaceUri: spaceUriOf(space) }
+  const parts = uri.startsWith('at://') ? uri.slice(5).split('/') : []
+  if (parts[1] === 'space') return { type: 'invalid' }
+  return isAtUriString(uri) ? { type: 'public' } : { type: 'invalid' }
+}
+
+export function classifyNotificationDomain(notification: {
+  uri: string
+  reasonSubject?: string
+}): NotificationDomain {
+  const record = uriDomain(notification.uri)
+  if (record.type === 'invalid') return record
+  if (!notification.reasonSubject) return record
+
+  const subject = uriDomain(notification.reasonSubject)
+  if (subject.type === 'invalid' || subject.type !== record.type) {
+    return { type: 'invalid' }
+  }
+  if (
+    record.type === 'space' &&
+    subject.type === 'space' &&
+    record.spaceUri !== subject.spaceUri
+  ) {
+    return { type: 'invalid' }
+  }
+  return record
+}

--- a/packages/bsky/src/api/app/bsky/notification/getUnreadCount.test.ts
+++ b/packages/bsky/src/api/app/bsky/notification/getUnreadCount.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { canViewSpace } from '../../../community/blacksky/tenant-gate.js'
+import { runNotificationCount } from './getUnreadCount.js'
+
+vi.mock('../../../community/blacksky/tenant-gate.js', () => ({
+  canViewSpace: vi.fn(),
+}))
+
+const firstSpace = 'at://did:plc:tenant/space/community.blacksky.feed/first'
+const secondSpace = 'at://did:plc:tenant/space/community.blacksky.feed/second'
+const viewer = 'did:plc:viewer'
+
+const context = () => {
+  const getUnreadNotificationSpaces = vi.fn(async () => ({
+    spaces: [
+      { postUri: `${firstSpace}/post/one`, spaceUri: firstSpace },
+      { postUri: `${firstSpace}/post/two`, spaceUri: firstSpace },
+      { postUri: `${secondSpace}/post/three`, spaceUri: secondSpace },
+    ],
+  }))
+  const getUnreadNotificationCount = vi.fn(
+    async ({ allowedSpaceUris }: { allowedSpaceUris: string[] }) => ({
+      count: 2 + allowedSpaceUris.length,
+    }),
+  )
+  return {
+    ctx: {
+      hydrator: {
+        dataplane: {
+          getUnreadNotificationSpaces,
+          getUnreadNotificationCount,
+        },
+      },
+    } as any,
+    getUnreadNotificationSpaces,
+    getUnreadNotificationCount,
+  }
+}
+
+describe(runNotificationCount, () => {
+  beforeEach(() => {
+    vi.mocked(canViewSpace).mockReset()
+  })
+
+  it('deduplicates candidates and counts public plus authorized spaces', async () => {
+    const { ctx, getUnreadNotificationCount } = context()
+    vi.mocked(canViewSpace).mockImplementation(async (_ctx, spaceUri) =>
+      Promise.resolve(spaceUri === firstSpace),
+    )
+
+    await expect(
+      runNotificationCount({ viewer }, ctx, 'authorized-union'),
+    ).resolves.toEqual({ count: 3 })
+    expect(canViewSpace).toHaveBeenCalledTimes(2)
+    expect(canViewSpace).toHaveBeenCalledWith(ctx, firstSpace, viewer)
+    expect(canViewSpace).toHaveBeenCalledWith(ctx, secondSpace, viewer)
+    expect(getUnreadNotificationCount).toHaveBeenCalledWith({
+      actorDid: viewer,
+      priority: false,
+      allowedSpaceUris: [firstSpace],
+    })
+  })
+
+  it('fails closed when one space authorization throws', async () => {
+    const { ctx, getUnreadNotificationCount } = context()
+    vi.mocked(canViewSpace).mockImplementation(async (_ctx, spaceUri) => {
+      if (spaceUri === firstSpace) throw new Error('authorization unavailable')
+      return true
+    })
+
+    await expect(
+      runNotificationCount({ viewer }, ctx, 'authorized-union'),
+    ).resolves.toEqual({ count: 3 })
+    expect(getUnreadNotificationCount).toHaveBeenCalledWith({
+      actorDid: viewer,
+      priority: false,
+      allowedSpaceUris: [secondSpace],
+    })
+  })
+
+  it('makes no candidate or authorization calls in public-only mode', async () => {
+    const { ctx, getUnreadNotificationSpaces, getUnreadNotificationCount } =
+      context()
+
+    await expect(
+      runNotificationCount({ viewer, priority: true }, ctx, 'public-only'),
+    ).resolves.toEqual({ count: 2 })
+    expect(getUnreadNotificationSpaces).not.toHaveBeenCalled()
+    expect(canViewSpace).not.toHaveBeenCalled()
+    expect(getUnreadNotificationCount).toHaveBeenCalledWith({
+      actorDid: viewer,
+      priority: true,
+      allowedSpaceUris: [],
+    })
+  })
+})

--- a/packages/bsky/src/api/app/bsky/notification/getUnreadCount.ts
+++ b/packages/bsky/src/api/app/bsky/notification/getUnreadCount.ts
@@ -1,7 +1,6 @@
 import type { DidString } from '@atproto/syntax'
 import { InvalidRequestError, type Server } from '@atproto/xrpc-server'
 import type { AppContext } from '../../../../context.js'
-import type { Hydrator } from '../../../../hydration/hydrator.js'
 import { app } from '../../../../lexicons/index.js'
 import {
   type HydrationFnInput,
@@ -10,27 +9,40 @@ import {
   createPipeline,
   noRules,
 } from '../../../../pipeline.js'
-import type { Views } from '../../../../views/index.js'
-import { canViewCommunityPost } from '../../../community/blacksky/tenant-gate.js'
+import { canViewSpace } from '../../../community/blacksky/tenant-gate.js'
+
+export type NotificationCountMode = 'public-only' | 'authorized-union'
 
 export default function (server: Server, ctx: AppContext) {
-  const getUnreadCount = createPipeline(
-    skeleton,
-    hydration,
-    noRules,
-    presentation,
-  )
   server.add(app.bsky.notification.getUnreadCount, {
     auth: ctx.authVerifier.standard,
     handler: async ({ auth, params }) => {
       const viewer = auth.credentials.iss
-      const result = await getUnreadCount({ ...params, viewer }, ctx)
+      const result = await runNotificationCount(
+        { ...params, viewer },
+        ctx,
+        'public-only',
+      )
       return {
         encoding: 'application/json',
         body: result,
       }
     },
   })
+}
+
+export async function runNotificationCount(
+  params: Omit<Params, 'mode'>,
+  ctx: AppContext,
+  mode: NotificationCountMode,
+) {
+  const getUnreadCount = createPipeline(
+    skeleton,
+    hydration,
+    noRules,
+    presentation,
+  )
+  return await getUnreadCount({ ...params, mode }, ctx)
 }
 
 const skeleton = async (
@@ -44,27 +56,27 @@ const skeleton = async (
   // (no client UI to clear it). Honor priority only when explicitly requested so
   // the unread count stays consistent with the notification list (see BA-271).
   const priority = params.priority ?? false
-  const candidates = await ctx.hydrator.dataplane.getUnreadNotificationSpaces({
-    actorDid: params.viewer,
-    priority,
-  })
-  const decisions = await Promise.all(
-    candidates.spaces.map(async (candidate) => ({
-      spaceUri: candidate.spaceUri,
-      allowed: await canViewCommunityPost(
-        ctx as AppContext,
-        { uri: candidate.postUri, spaceUri: candidate.spaceUri },
-        params.viewer,
-      ),
-    })),
-  )
-  const allowedSpaceUris = [
-    ...new Set(
-      decisions
-        .filter((decision) => decision.allowed)
-        .map((decision) => decision.spaceUri),
-    ),
-  ]
+  let allowedSpaceUris: string[] = []
+  if (params.mode === 'authorized-union') {
+    const candidates = await ctx.hydrator.dataplane.getUnreadNotificationSpaces(
+      {
+        actorDid: params.viewer,
+        priority,
+      },
+    )
+    const spaces = [...new Set(candidates.spaces.map((item) => item.spaceUri))]
+    const decisions = await Promise.all(
+      spaces.map(async (spaceUri) => ({
+        spaceUri,
+        allowed: await canViewSpace(ctx, spaceUri, params.viewer).catch(
+          () => false,
+        ),
+      })),
+    )
+    allowedSpaceUris = decisions
+      .filter((decision) => decision.allowed)
+      .map((decision) => decision.spaceUri)
+  }
   const res = await ctx.hydrator.dataplane.getUnreadNotificationCount({
     actorDid: params.viewer,
     priority,
@@ -88,13 +100,11 @@ const presentation = (
   return { count: skeleton.count }
 }
 
-type Context = {
-  hydrator: Hydrator
-  views: Views
-}
+type Context = AppContext
 
 type Params = app.bsky.notification.getUnreadCount.$Params & {
   viewer: DidString
+  mode: NotificationCountMode
 }
 
 type SkeletonState = {

--- a/packages/bsky/src/api/app/bsky/notification/listNotifications.test.ts
+++ b/packages/bsky/src/api/app/bsky/notification/listNotifications.test.ts
@@ -1,0 +1,144 @@
+import { Timestamp } from '@bufbuild/protobuf'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { canViewSpace } from '../../../community/blacksky/tenant-gate.js'
+import { paginateNotifications } from './listNotifications.js'
+
+vi.mock('../../../community/blacksky/tenant-gate.js', () => ({
+  canViewSpace: vi.fn(),
+}))
+
+const firstSpace = 'at://did:plc:tenant/space/community.blacksky.feed/first'
+const secondSpace = 'at://did:plc:tenant/space/community.blacksky.feed/second'
+
+const notification = (uri: string, index: number) => ({
+  recipientDid: 'did:plc:viewer',
+  uri,
+  reason: 'mention',
+  reasonSubject: uri,
+  timestamp: Timestamp.fromDate(new Date(Date.UTC(2026, 8, 1, 0, 0, index))),
+  priority: false,
+})
+
+const publicUri = (index: number) =>
+  `at://did:plc:alice/app.bsky.feed.post/public-${index}`
+
+const spaceUri = (space: string, index: number) =>
+  `${space}/did:plc:alice/app.bsky.feed.post/private-${index}`
+
+const contextFor = (notifications: ReturnType<typeof notification>[]) => {
+  const getNotifications = vi.fn(
+    async (req: { cursor?: string; limit: number }) => {
+      const offset = req.cursor
+        ? notifications.findIndex(
+            (item) => item.timestamp?.toDate().toISOString() === req.cursor,
+          ) + 1
+        : 0
+      const page = notifications.slice(offset, offset + req.limit)
+      return {
+        notifications: page,
+        cursor: page.at(-1)?.timestamp?.toDate().toISOString(),
+      }
+    },
+  )
+  return {
+    ctx: { hydrator: { dataplane: { getNotifications } } } as any,
+    getNotifications,
+  }
+}
+
+describe(paginateNotifications, () => {
+  beforeEach(() => {
+    vi.mocked(canViewSpace).mockReset()
+  })
+
+  it('keeps mixed notifications ordered and owns the last consumed cursor', async () => {
+    const rows = [
+      notification(publicUri(0), 0),
+      notification(spaceUri(secondSpace, 1), 1),
+      notification(spaceUri(firstSpace, 2), 2),
+      notification(publicUri(3), 3),
+      notification(publicUri(4), 4),
+    ]
+    const { ctx, getNotifications } = contextFor(rows)
+    vi.mocked(canViewSpace).mockImplementation(async (_ctx, space) =>
+      Promise.resolve(space === firstSpace),
+    )
+
+    const first = await paginateNotifications({
+      ctx,
+      priority: false,
+      limit: 3,
+      viewer: 'did:plc:viewer',
+      mode: 'authorized-union',
+    })
+    expect(first.notifications.map((item) => item.uri)).toEqual([
+      rows[0].uri,
+      rows[2].uri,
+      rows[3].uri,
+    ])
+    expect(first.cursor).toBe(rows[3].timestamp?.toDate().toISOString())
+    expect(getNotifications.mock.calls[0][0]).toMatchObject({
+      includeSpaceNotifications: true,
+    })
+
+    const second = await paginateNotifications({
+      ctx,
+      priority: false,
+      cursor: first.cursor,
+      limit: 3,
+      viewer: 'did:plc:viewer',
+      mode: 'authorized-union',
+    })
+    expect(second.notifications.map((item) => item.uri)).toEqual([rows[4].uri])
+  })
+
+  it('returns an advancing empty page when the denied scan reaches its cap', async () => {
+    const rows = Array.from({ length: 1_001 }, (_, index) =>
+      index < 1_000
+        ? notification(spaceUri(firstSpace, index), index)
+        : notification(publicUri(index), index),
+    )
+    const { ctx } = contextFor(rows)
+    vi.mocked(canViewSpace).mockResolvedValue(false)
+
+    const denied = await paginateNotifications({
+      ctx,
+      priority: false,
+      limit: 1,
+      viewer: 'did:plc:viewer',
+      mode: 'authorized-union',
+    })
+    expect(denied.notifications).toEqual([])
+    expect(denied.cursor).toBe(rows[999].timestamp?.toDate().toISOString())
+
+    const continued = await paginateNotifications({
+      ctx,
+      priority: false,
+      cursor: denied.cursor,
+      limit: 1,
+      viewer: 'did:plc:viewer',
+      mode: 'authorized-union',
+    })
+    expect(continued.notifications.map((item) => item.uri)).toEqual([
+      rows[1_000].uri,
+    ])
+  })
+
+  it('does not authorize spaces in public-only mode', async () => {
+    const { ctx, getNotifications } = contextFor([
+      notification(publicUri(0), 0),
+    ])
+    const result = await paginateNotifications({
+      ctx,
+      priority: false,
+      limit: 1,
+      viewer: 'did:plc:viewer',
+      mode: 'public-only',
+    })
+    expect(result.notifications).toHaveLength(1)
+    expect(canViewSpace).not.toHaveBeenCalled()
+    expect(getNotifications.mock.calls[0][0]).toMatchObject({
+      includeSpaceNotifications: false,
+    })
+  })
+})

--- a/packages/bsky/src/api/app/bsky/notification/listNotifications.test.ts
+++ b/packages/bsky/src/api/app/bsky/notification/listNotifications.test.ts
@@ -140,6 +140,10 @@ describe(paginateNotifications, () => {
     expect(canViewSpace).not.toHaveBeenCalled()
     expect(getNotifications.mock.calls[0][0]).toMatchObject({
       includeSpaceNotifications: false,
+      limit: 1,
     })
+    expect(result.cursor).toBe(
+      notification(publicUri(0), 0).timestamp?.toDate().toISOString(),
+    )
   })
 })

--- a/packages/bsky/src/api/app/bsky/notification/listNotifications.test.ts
+++ b/packages/bsky/src/api/app/bsky/notification/listNotifications.test.ts
@@ -90,6 +90,7 @@ describe(paginateNotifications, () => {
       mode: 'authorized-union',
     })
     expect(second.notifications.map((item) => item.uri)).toEqual([rows[4].uri])
+    expect(second.cursor).toBeUndefined()
   })
 
   it('returns an advancing empty page when the denied scan reaches its cap', async () => {

--- a/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
+++ b/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
@@ -1,7 +1,6 @@
 import { mapDefined } from '@atproto/common'
 import type { AtUriString, DatetimeString } from '@atproto/syntax'
 import { InvalidRequestError, type Server } from '@atproto/xrpc-server'
-import type { ServerConfig } from '../../../../config.js'
 import type { AppContext } from '../../../../context.js'
 import type {
   HydrateCtxWithViewer,
@@ -20,14 +19,17 @@ import {
   uriToAuthorDid,
   uriToDid as didFromUri,
 } from '../../../../util/uris.js'
-import type { Views } from '../../../../views/index.js'
 import { isPostRecordType } from '../../../../views/types.js'
+import { canViewSpace } from '../../../community/blacksky/tenant-gate.js'
 import { resHeaders } from '../../../util.js'
+import { classifyNotificationDomain } from './domain.js'
 import { protobufToLex } from './util.js'
-import { spaceOfRecordUri } from '../../../community/blacksky/space-uri.js'
-import { canViewCommunityPost } from '../../../community/blacksky/tenant-gate.js'
 
 const ALL_NOTIFICATION_REASONS_COUNT = 10
+const AUTHORIZED_UNION_SCAN_CAP = 1_000
+const NOTIFICATION_BATCH_SIZE = 100
+
+export type NotificationListMode = 'public-only' | 'authorized-union'
 
 type PreferenceFilters = {
   reasons?: string[]
@@ -80,19 +82,17 @@ const getPreferenceFilters = async (
 }
 
 export default function (server: Server, ctx: AppContext) {
-  const listNotifications = createPipeline(
-    skeleton,
-    hydration,
-    noBlockOrMutesOrNeedsFiltering,
-    presentation,
-  )
   server.add(app.bsky.notification.listNotifications, {
     auth: ctx.authVerifier.standard,
     handler: async ({ params, auth, req }) => {
       const viewer = auth.credentials.iss
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
-      const result = await listNotifications({ ...params, hydrateCtx }, ctx)
+      const result = await runNotificationList(
+        { ...params, hydrateCtx },
+        ctx,
+        'public-only',
+      )
       return {
         encoding: 'application/json',
         body: result,
@@ -102,53 +102,90 @@ export default function (server: Server, ctx: AppContext) {
   })
 }
 
-const paginateNotifications = async (opts: {
+export async function runNotificationList(
+  params: Omit<Params, 'mode'>,
+  ctx: AppContext,
+  mode: NotificationListMode,
+) {
+  const listNotifications = createPipeline(
+    skeleton,
+    hydration,
+    noBlockOrMutesOrNeedsFiltering,
+    presentation,
+  )
+  return await listNotifications({ ...params, mode }, ctx)
+}
+
+export async function paginateNotifications(opts: {
   ctx: Context
   priority: boolean
   reasons?: string[]
   cursor?: string
   limit: number
   viewer: string
-}) => {
-  const { ctx, priority, reasons, limit, viewer } = opts
-
-  // if not filtering, then just pass through the response from dataplane
-  if (!reasons) {
-    const res = await ctx.hydrator.dataplane.getNotifications({
-      actorDid: viewer,
-      priority,
-      cursor: opts.cursor,
-      limit,
-    })
-    return {
-      notifications: res.notifications,
-      cursor: res.cursor,
-    }
-  }
-
+  mode: NotificationListMode
+}) {
+  const { ctx, priority, reasons, limit, viewer, mode } = opts
   let nextCursor: string | undefined = opts.cursor
-  let toReturn: Notification[] = []
-  const maxAttempts = 10
-  const attemptSize = Math.ceil(limit / 2)
-  for (let i = 0; i < maxAttempts; i++) {
+  const toReturn: Notification[] = []
+  const access = new Map<string, Promise<boolean>>()
+  let consumed = 0
+  let consumedCursor: string | undefined
+
+  while (consumed < AUTHORIZED_UNION_SCAN_CAP) {
+    const batchLimit = Math.min(
+      NOTIFICATION_BATCH_SIZE,
+      AUTHORIZED_UNION_SCAN_CAP - consumed,
+    )
     const res = await ctx.hydrator.dataplane.getNotifications({
       actorDid: viewer,
       priority,
       cursor: nextCursor,
-      limit,
+      limit: batchLimit,
+      includeSpaceNotifications: mode === 'authorized-union',
     })
-    const filtered = res.notifications.filter((notif) =>
-      reasons.includes(notif.reason),
-    )
-    toReturn = [...toReturn, ...filtered]
+    if (res.notifications.length === 0) {
+      return { notifications: toReturn, cursor: undefined }
+    }
+
+    const domains = res.notifications.map(classifyNotificationDomain)
+    if (mode === 'authorized-union') {
+      for (const domain of domains) {
+        if (domain.type === 'space' && !access.has(domain.spaceUri)) {
+          access.set(
+            domain.spaceUri,
+            canViewSpace(ctx, domain.spaceUri, viewer),
+          )
+        }
+      }
+    }
+
+    for (const [index, notification] of res.notifications.entries()) {
+      consumed++
+      consumedCursor = notification.timestamp?.toDate().toISOString()
+      const domain = domains[index]
+      let allowed = domain.type === 'public'
+      if (mode === 'authorized-union' && domain.type === 'space') {
+        const decision = access.get(domain.spaceUri)
+        allowed = decision ? await decision : false
+      }
+      if (allowed && (!reasons || reasons.includes(notification.reason))) {
+        toReturn.push(notification)
+      }
+      if (toReturn.length >= limit) {
+        return { notifications: toReturn, cursor: consumedCursor }
+      }
+      if (consumed >= AUTHORIZED_UNION_SCAN_CAP) break
+    }
+
     nextCursor = res.cursor ?? undefined
-    if (toReturn.length >= attemptSize || !nextCursor) {
-      break
+    if (!nextCursor || res.notifications.length < batchLimit) {
+      return { notifications: toReturn, cursor: nextCursor }
     }
   }
   return {
     notifications: toReturn,
-    cursor: nextCursor,
+    cursor: consumedCursor,
   }
 }
 
@@ -198,28 +235,13 @@ const skeleton = async (
       cursor: delayedCursor,
       limit: params.limit,
       viewer,
+      mode: params.mode,
     }),
     ctx.hydrator.dataplane.getNotificationSeen({
       actorDid: viewer,
       priority,
     }),
   ])
-  const visible = await Promise.all(
-    res.notifications.map(async (notification) => {
-      const spaceUri = spaceOfRecordUri(notification.uri)
-      if (!spaceUri) return true
-      try {
-        return await canViewCommunityPost(
-          ctx as AppContext,
-          { uri: notification.uri, spaceUri },
-          viewer,
-        )
-      } catch {
-        return false
-      }
-    }),
-  )
-  res.notifications = res.notifications.filter((_, index) => visible[index])
   // @NOTE for the first page of results if there's no last-seen time, consider top notification unread
   // rather than all notifications. bit of a hack to be more graceful when seen times are out of sync.
   let lastSeenDate = lastSeenRes.timestamp?.toDate()
@@ -349,14 +371,11 @@ const presentation = (
   }
 }
 
-type Context = {
-  hydrator: Hydrator
-  views: Views
-  cfg: ServerConfig
-}
+type Context = AppContext
 
 type Params = app.bsky.notification.listNotifications.$Params & {
   hydrateCtx: HydrateCtxWithViewer
+  mode: NotificationListMode
 }
 
 type SkeletonState = {

--- a/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
+++ b/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
@@ -180,7 +180,7 @@ export async function paginateNotifications(opts: {
 
     nextCursor = res.cursor ?? undefined
     if (!nextCursor || res.notifications.length < batchLimit) {
-      return { notifications: toReturn, cursor: nextCursor }
+      return { notifications: toReturn, cursor: undefined }
     }
   }
   return {

--- a/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
+++ b/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
@@ -126,6 +126,20 @@ export async function paginateNotifications(opts: {
   mode: NotificationListMode
 }) {
   const { ctx, priority, reasons, limit, viewer, mode } = opts
+  if (mode === 'public-only' && !reasons) {
+    const res = await ctx.hydrator.dataplane.getNotifications({
+      actorDid: viewer,
+      priority,
+      cursor: opts.cursor,
+      limit,
+      includeSpaceNotifications: false,
+    })
+    return {
+      notifications: res.notifications,
+      cursor: res.cursor,
+    }
+  }
+
   let nextCursor: string | undefined = opts.cursor
   const toReturn: Notification[] = []
   const access = new Map<string, Promise<boolean>>()

--- a/packages/bsky/src/api/community/blacksky/notification/getUnreadCount.ts
+++ b/packages/bsky/src/api/community/blacksky/notification/getUnreadCount.ts
@@ -1,0 +1,22 @@
+import type { Server } from '@atproto/xrpc-server'
+import type { AppContext } from '../../../../context.js'
+import { community } from '../../../../lexicons/index.js'
+import { runNotificationCount } from '../../../app/bsky/notification/getUnreadCount.js'
+
+export default function (server: Server, ctx: AppContext) {
+  server.add(community.blacksky.notification.getUnreadCount, {
+    auth: ctx.authVerifier.standard,
+    handler: async ({ auth, params }) => {
+      const viewer = auth.credentials.iss
+      const result = await runNotificationCount(
+        { ...params, viewer },
+        ctx,
+        'authorized-union',
+      )
+      return {
+        encoding: 'application/json',
+        body: result,
+      }
+    },
+  })
+}

--- a/packages/bsky/src/api/community/blacksky/notification/listNotifications.ts
+++ b/packages/bsky/src/api/community/blacksky/notification/listNotifications.ts
@@ -1,0 +1,34 @@
+import type { Server } from '@atproto/xrpc-server'
+import type { AppContext } from '../../../../context.js'
+import { community } from '../../../../lexicons/index.js'
+import { runNotificationList } from '../../../app/bsky/notification/listNotifications.js'
+import { resHeaders } from '../../../util.js'
+
+export default function (server: Server, ctx: AppContext) {
+  server.add(community.blacksky.notification.listNotifications, {
+    auth: ctx.authVerifier.standard,
+    handler: async ({ params, auth, req }) => {
+      const viewer = auth.credentials.iss
+      const labelers = ctx.reqLabelers(req)
+      const hydrateCtx = await ctx.hydrator.createContext({ labelers, viewer })
+      const result = await runNotificationList(
+        { ...params, hydrateCtx },
+        ctx,
+        'authorized-union',
+      )
+      const body: community.blacksky.notification.listNotifications.$OutputBody =
+        {
+          ...result,
+          notifications: result.notifications.map((notification) => ({
+            ...notification,
+            $type: undefined,
+          })),
+        }
+      return {
+        encoding: 'application/json',
+        body,
+        headers: resHeaders({ labelers: hydrateCtx.labelers }),
+      }
+    },
+  })
+}

--- a/packages/bsky/src/api/index.ts
+++ b/packages/bsky/src/api/index.ts
@@ -99,7 +99,6 @@ import resolveHandle from './com/atproto/identity/resolveHandle.js'
 import queryLabels from './com/atproto/label/queryLabels.js'
 import getRecord from './com/atproto/repo/getRecord.js'
 import fetchLabels from './com/atproto/temp/fetchLabels.js'
-import internalGetProfiles from './internal/bsky/actor/getProfiles.js'
 import checkCommunityMembership from './community/blacksky/actor/checkMembership.js'
 import getActorBadges from './community/blacksky/badge/getBadges.js'
 import grantBadge from './community/blacksky/badge/grantBadge.js'
@@ -108,17 +107,20 @@ import deleteCommunityPost from './community/blacksky/feed/deletePost.js'
 import getCommunityFeed from './community/blacksky/feed/getCommunityFeed.js'
 import getCommunityPost from './community/blacksky/feed/getCommunityPost.js'
 import getCommunityThread from './community/blacksky/feed/getCommunityThread.js'
-import getSpaceFeed from './community/blacksky/feed/getSpaceFeed.js'
-import setThreadMute from './community/blacksky/feed/setThreadMute.js'
 import getCommunityTimeline from './community/blacksky/feed/getCommunityTimeline.js'
+import getSpaceFeed from './community/blacksky/feed/getSpaceFeed.js'
 import getSpacePostLikes from './community/blacksky/feed/getSpacePostLikes.js'
 import getSpacePostQuotes from './community/blacksky/feed/getSpacePostQuotes.js'
+import setThreadMute from './community/blacksky/feed/setThreadMute.js'
 import submitCommunityPost from './community/blacksky/feed/submitPost.js'
 import applyPeerModLabel from './community/blacksky/moderation/applyLabel.js'
 import getMyPeerModLabels from './community/blacksky/moderation/getMyLabels.js'
 import getMyPeerModPermissions from './community/blacksky/moderation/getMyPermissions.js'
 import removePeerModLabel from './community/blacksky/moderation/removeLabel.js'
+import getCommunityUnreadCount from './community/blacksky/notification/getUnreadCount.js'
+import listCommunityNotifications from './community/blacksky/notification/listNotifications.js'
 import projectSpaceRecords from './community/blacksky/space/projectRecords.js'
+import internalGetProfiles from './internal/bsky/actor/getProfiles.js'
 
 export * as health from './health.js'
 
@@ -253,5 +255,7 @@ export default function (server: Server, ctx: AppContext) {
   revokeBadge(server, ctx)
   getActorBadges(server, ctx)
   checkCommunityMembership(server, ctx)
+  getCommunityUnreadCount(server, ctx)
+  listCommunityNotifications(server, ctx)
   projectSpaceRecords(server, ctx)
 }

--- a/packages/bsky/src/data-plane/server/routes/notifs.ts
+++ b/packages/bsky/src/data-plane/server/routes/notifs.ts
@@ -18,7 +18,7 @@ import { countAll, notSoftDeletedClause } from '../db/util.js'
 
 export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
   async getNotifications(req) {
-    const { actorDid, limit, cursor, priority } = req
+    const { actorDid, limit, cursor, priority, includeSpaceNotifications } = req
     const { ref } = db.db.dynamic
     const priorityFollowQb = db.db
       .selectFrom('follow')
@@ -42,7 +42,11 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
         sql<boolean>`(
           notif."reasonSubject" IS NULL OR
           CASE split_part(notif."reasonSubject", '/', 4)
-            WHEN 'space' THEN EXISTS (SELECT 1 FROM community_post cp WHERE cp.uri = notif."reasonSubject")
+            WHEN 'space' THEN EXISTS (
+              SELECT 1 FROM community_post cp
+              WHERE cp.uri = notif."reasonSubject"
+                AND cp.moderation_flagged_at IS NULL
+            )
             WHEN 'app.bsky.feed.like' THEN EXISTS (SELECT 1 FROM "like" l WHERE l.uri = notif."reasonSubject")
             WHEN 'app.bsky.feed.repost' THEN EXISTS (SELECT 1 FROM repost rp WHERE rp.uri = notif."reasonSubject")
             WHEN 'app.bsky.graph.follow' THEN EXISTS (SELECT 1 FROM follow f WHERE f.uri = notif."reasonSubject")
@@ -50,6 +54,28 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
             ELSE EXISTS (SELECT 1 FROM record r WHERE r.uri = notif."reasonSubject")
           END
         )`,
+      )
+      .$if(!includeSpaceNotifications, (qb) =>
+        qb.where(
+          sql<boolean>`(
+            split_part(notif."recordUri", '/', 4) <> 'space' AND
+            (
+              notif."reasonSubject" IS NULL OR
+              split_part(notif."reasonSubject", '/', 4) <> 'space'
+            )
+          )`,
+        ),
+      )
+      .$if(includeSpaceNotifications, (qb) =>
+        qb.where(
+          sql<boolean>`(
+            split_part(notif."recordUri", '/', 4) <> 'space' OR EXISTS (
+              SELECT 1 FROM community_post cp
+              WHERE cp.uri = notif."recordUri"
+                AND cp.moderation_flagged_at IS NULL
+            )
+          )`,
+        ),
       )
       .$if(priority, (qb) => qb.where(({ exists }) => exists(priorityFollowQb)))
       .select([
@@ -129,13 +155,38 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
       // analog of takedownRef.
       .where(
         sql<boolean>`(
-          CASE split_part(notification."recordUri", '/', 4)
-            WHEN 'space' THEN EXISTS (
+          (
+            split_part(notification."recordUri", '/', 4) <> 'space' AND
+            (
+              notification."reasonSubject" IS NULL OR
+              split_part(notification."reasonSubject", '/', 4) <> 'space'
+            )
+          ) OR (
+            split_part(notification."recordUri", '/', 4) = 'space' AND
+            (
+              notification."reasonSubject" IS NULL OR
+              split_part(notification."reasonSubject", '/', 4) = 'space'
+            ) AND EXISTS (
               SELECT 1 FROM community_post cp
               WHERE cp.uri = notification."recordUri"
                 AND cp.moderation_flagged_at IS NULL
-                AND (cp.space_uri IS NULL OR cp.space_uri = ANY(${sql.val(allowedSpaceUris)}::text[]))
+                AND cp.space_uri = ANY(${sql.val(allowedSpaceUris)}::text[])
+                AND (
+                  notification."reasonSubject" IS NULL OR EXISTS (
+                    SELECT 1 FROM community_post subject_cp
+                    WHERE subject_cp.uri = notification."reasonSubject"
+                      AND subject_cp.space_uri = cp.space_uri
+                      AND subject_cp.moderation_flagged_at IS NULL
+                  )
+                )
             )
+          )
+        )`,
+      )
+      .where(
+        sql<boolean>`(
+          CASE split_part(notification."recordUri", '/', 4)
+            WHEN 'space' THEN true
             WHEN 'app.bsky.feed.like' THEN EXISTS (SELECT 1 FROM "like" l WHERE l.uri = notification."recordUri" AND l."takedownRef" IS NULL)
             WHEN 'app.bsky.feed.repost' THEN EXISTS (SELECT 1 FROM repost rp WHERE rp.uri = notification."recordUri" AND rp."takedownRef" IS NULL)
             WHEN 'app.bsky.graph.follow' THEN EXISTS (SELECT 1 FROM follow f WHERE f.uri = notification."recordUri" AND f."takedownRef" IS NULL)
@@ -196,6 +247,14 @@ export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
          AND notification."sortAt" > $2
          AND cp.space_uri IS NOT NULL
          AND cp.moderation_flagged_at IS NULL
+         AND (
+           notification."reasonSubject" IS NULL OR EXISTS (
+             SELECT 1 FROM community_post subject_cp
+             WHERE subject_cp.uri = notification."reasonSubject"
+               AND subject_cp.space_uri = cp.space_uri
+               AND subject_cp.moderation_flagged_at IS NULL
+           )
+         )
          ${priorityClause}`,
       params,
     )

--- a/packages/bsky/tests/community/notification-contract.test.ts
+++ b/packages/bsky/tests/community/notification-contract.test.ts
@@ -1,0 +1,181 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { runNotificationList } from '../../src/api/app/bsky/notification/listNotifications.js'
+import registerCommunityNotificationList from '../../src/api/community/blacksky/notification/listNotifications.js'
+import * as StandardUnreadCount from '../../src/lexicons/app/bsky/notification/getUnreadCount.js'
+import * as StandardNotifications from '../../src/lexicons/app/bsky/notification/listNotifications.js'
+import * as CommunityUnreadCount from '../../src/lexicons/community/blacksky/notification/getUnreadCount.js'
+import * as CommunityNotifications from '../../src/lexicons/community/blacksky/notification/listNotifications.js'
+
+vi.mock('../../src/api/app/bsky/notification/listNotifications.js', () => ({
+  runNotificationList: vi.fn(),
+}))
+
+const space = 'at://did:plc:tenant/space/community.blacksky.feed/private'
+const privateUri = `${space}/did:plc:alice/app.bsky.feed.post/3kprivate`
+const cid = 'bafyreiacsg6vsw7ppwbnowzsdgstulhrwftirtcnvkcbnfgvhwjrnzfmsu'
+
+const privateNotification = {
+  uri: privateUri,
+  cid,
+  author: { did: 'did:plc:alice', handle: 'alice.test' },
+  reason: 'mention',
+  reasonSubject: privateUri,
+  record: {
+    $type: 'app.bsky.feed.post',
+    text: 'private',
+    createdAt: '2026-09-01T00:00:00.000Z',
+  },
+  isRead: false,
+  indexedAt: '2026-09-01T00:00:00.000Z',
+}
+
+const pipelinePrivateNotification = {
+  ...privateNotification,
+  $type: 'app.bsky.notification.listNotifications#notification' as const,
+}
+
+const publicNotification = {
+  ...privateNotification,
+  uri: 'at://did:plc:alice/app.bsky.feed.post/3kpublic',
+  reasonSubject: 'at://did:plc:alice/app.bsky.feed.post/3kpublic',
+}
+
+const completeBody = (notification: typeof privateNotification) => ({
+  cursor: '2026-08-31T23:59:59.000Z',
+  notifications: [notification],
+  priority: true,
+  seenAt: '2026-09-01T00:00:00.000Z',
+})
+
+const readLexicon = (path: string) =>
+  JSON.parse(
+    readFileSync(fileURLToPath(new URL(path, import.meta.url)), 'utf8'),
+  )
+
+describe('private notification contract', () => {
+  beforeEach(() => {
+    vi.mocked(runNotificationList).mockReset()
+  })
+
+  it('accepts a complete private response only on the Blacksky schema', () => {
+    const body = completeBody(privateNotification)
+
+    expect(CommunityNotifications.$output.schema.$safeParse(body).success).toBe(
+      true,
+    )
+    expect(StandardNotifications.$output.schema.$safeParse(body).success).toBe(
+      false,
+    )
+  })
+
+  it('keeps complete public responses valid on both schemas', () => {
+    const body = completeBody(publicNotification)
+
+    expect(StandardNotifications.$output.schema.$safeParse(body).success).toBe(
+      true,
+    )
+    expect(CommunityNotifications.$output.schema.$safeParse(body).success).toBe(
+      true,
+    )
+  })
+
+  it('serializes the custom route without the standard notification discriminator', async () => {
+    let route: any
+    const server = {
+      add: vi.fn((_schema, config) => {
+        route = config
+      }),
+    }
+    const ctx = {
+      authVerifier: { standard: vi.fn() },
+      reqLabelers: vi.fn(() => undefined),
+      hydrator: {
+        createContext: vi.fn(async () => ({ labelers: undefined })),
+      },
+    } as any
+    vi.mocked(runNotificationList).mockResolvedValue(
+      completeBody(pipelinePrivateNotification) as any,
+    )
+    registerCommunityNotificationList(server as any, ctx)
+
+    const response = await route.handler({
+      params: { limit: 50 },
+      auth: { credentials: { iss: 'did:plc:viewer' } },
+      req: {},
+    })
+    const wireBody = JSON.parse(JSON.stringify(response.body))
+
+    expect(runNotificationList).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 50 }),
+      ctx,
+      'authorized-union',
+    )
+    expect(wireBody).toMatchObject({
+      cursor: '2026-08-31T23:59:59.000Z',
+      priority: true,
+      seenAt: '2026-09-01T00:00:00.000Z',
+    })
+    expect(wireBody.notifications[0]).not.toHaveProperty('$type')
+    expect(
+      CommunityNotifications.$output.schema.$safeParse(wireBody).success,
+    ).toBe(true)
+    expect(
+      StandardNotifications.$output.schema.$safeParse(wireBody).success,
+    ).toBe(false)
+  })
+
+  it('mirrors standard list and unread-count query parameter contracts', () => {
+    const standardList = readLexicon(
+      '../../../../lexicons/app/bsky/notification/listNotifications.json',
+    )
+    const communityList = readLexicon(
+      '../../../../lexicons/community/blacksky/notification/listNotifications.json',
+    )
+    const standardCount = readLexicon(
+      '../../../../lexicons/app/bsky/notification/getUnreadCount.json',
+    )
+    const communityCount = readLexicon(
+      '../../../../lexicons/community/blacksky/notification/getUnreadCount.json',
+    )
+
+    expect(communityList.defs.main.parameters).toEqual(
+      standardList.defs.main.parameters,
+    )
+    expect(communityCount.defs.main.parameters).toEqual(
+      standardCount.defs.main.parameters,
+    )
+
+    for (const params of [
+      StandardNotifications.$params,
+      CommunityNotifications.$params,
+    ]) {
+      expect(params.$safeParse({ limit: 0 }).success).toBe(false)
+      expect(params.$safeParse({ limit: 101 }).success).toBe(false)
+      expect(
+        params.$safeParse({
+          reasons: ['mention'],
+          limit: 100,
+          priority: true,
+          cursor: 'cursor',
+          seenAt: '2026-09-01T00:00:00.000Z',
+        }).success,
+      ).toBe(true)
+    }
+    for (const params of [
+      StandardUnreadCount.$params,
+      CommunityUnreadCount.$params,
+    ]) {
+      expect(
+        params.$safeParse({
+          priority: true,
+          seenAt: '2026-09-01T00:00:00.000Z',
+        }).success,
+      ).toBe(true)
+      expect(params.$safeParse({ seenAt: 'not-a-datetime' }).success).toBe(
+        false,
+      )
+    }
+  })
+})

--- a/packages/bsky/tests/data-plane/community-posts.test.ts
+++ b/packages/bsky/tests/data-plane/community-posts.test.ts
@@ -1,11 +1,12 @@
+import { Timestamp } from '@bufbuild/protobuf'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { TestNetwork } from '@atproto/dev-env'
-import { FeedType } from '../../src/proto/bsky_pb.js'
 import communityRoutes from '../../src/data-plane/server/routes/community.js'
 import feedRoutes from '../../src/data-plane/server/routes/feeds.js'
 import likeRoutes from '../../src/data-plane/server/routes/likes.js'
 import notificationRoutes from '../../src/data-plane/server/routes/notifs.js'
-import { Database } from '../../src/index.js'
+import type { Database } from '../../src/index.js'
+import { FeedType } from '../../src/proto/bsky_pb.js'
 
 describe('community post tenant discriminator', () => {
   let network: TestNetwork
@@ -626,7 +627,9 @@ describe('community post tenant discriminator', () => {
     const secondSpace =
       'at://did:plc:tenant/space/community.blacksky.feed/second'
     const firstPost = `${firstSpace}/did:plc:alice/app.bsky.feed.post/first`
+    const firstSubject = `${firstSpace}/did:plc:bob/app.bsky.feed.post/first-subject`
     const secondPost = `${secondSpace}/did:plc:alice/app.bsky.feed.post/second`
+    const publicPost = 'at://did:plc:alice/app.bsky.feed.post/public'
     const now = new Date().toISOString()
     await db.db
       .insertInto('actor')
@@ -645,17 +648,41 @@ describe('community post tenant discriminator', () => {
       .onConflict((conflict) => conflict.doNothing())
       .execute()
     await insertPost(firstPost, firstSpace)
+    await insertPost(firstSubject, firstSpace)
     await insertPost(secondPost, secondSpace)
+    await db.db
+      .insertInto('record')
+      .values({
+        uri: publicPost,
+        cid: 'bafypublic',
+        did: 'did:plc:alice',
+        json: JSON.stringify({
+          $type: 'app.bsky.feed.post',
+          text: 'public',
+          createdAt: now,
+        }),
+        indexedAt: now,
+      })
+      .execute()
     await db.db
       .insertInto('notification')
       .values([
+        {
+          did: viewer,
+          recordUri: publicPost,
+          recordCid: 'bafypublic',
+          author: 'did:plc:alice',
+          reason: 'mention',
+          reasonSubject: null,
+          sortAt: now,
+        },
         {
           did: viewer,
           recordUri: firstPost,
           recordCid: 'bafyfirst',
           author: 'did:plc:alice',
           reason: 'mention',
-          reasonSubject: null,
+          reasonSubject: firstSubject,
           sortAt: now,
         },
         {
@@ -667,9 +694,50 @@ describe('community post tenant discriminator', () => {
           reasonSubject: null,
           sortAt: now,
         },
+        {
+          did: viewer,
+          recordUri: firstPost,
+          recordCid: 'bafycross',
+          author: 'did:plc:alice',
+          reason: 'reply',
+          reasonSubject: secondPost,
+          sortAt: now,
+        },
+        {
+          did: viewer,
+          recordUri: publicPost,
+          recordCid: 'bafypublicprivate',
+          author: 'did:plc:alice',
+          reason: 'quote',
+          reasonSubject: firstPost,
+          sortAt: now,
+        },
+        {
+          did: viewer,
+          recordUri: secondPost,
+          recordCid: 'bafyprivatepublic',
+          author: 'did:plc:alice',
+          reason: 'reply',
+          reasonSubject: publicPost,
+          sortAt: now,
+        },
       ])
       .execute()
     const routes = notificationRoutes(db) as any
+
+    const candidates = await routes.getUnreadNotificationSpaces({
+      actorDid: viewer,
+      priority: false,
+    })
+    expect(
+      candidates.spaces.sort(
+        (a: { spaceUri: string }, b: { spaceUri: string }) =>
+          a.spaceUri.localeCompare(b.spaceUri),
+      ),
+    ).toEqual([
+      { postUri: firstPost, spaceUri: firstSpace },
+      { postUri: secondPost, spaceUri: secondSpace },
+    ])
 
     await expect(
       routes.getUnreadNotificationCount({
@@ -677,14 +745,34 @@ describe('community post tenant discriminator', () => {
         priority: false,
         allowedSpaceUris: [firstSpace, secondSpace],
       }),
-    ).resolves.toEqual({ count: 2 })
+    ).resolves.toEqual({ count: 3 })
     await expect(
       routes.getUnreadNotificationCount({
         actorDid: viewer,
         priority: false,
         allowedSpaceUris: [firstSpace],
       }),
+    ).resolves.toEqual({ count: 2 })
+    await expect(
+      routes.getUnreadNotificationCount({
+        actorDid: viewer,
+        priority: false,
+        allowedSpaceUris: [],
+      }),
     ).resolves.toEqual({ count: 1 })
+
+    await routes.updateNotificationSeen({
+      actorDid: viewer,
+      timestamp: Timestamp.fromDate(new Date(now)),
+      priority: false,
+    })
+    await expect(
+      routes.getUnreadNotificationCount({
+        actorDid: viewer,
+        priority: false,
+        allowedSpaceUris: [firstSpace, secondSpace],
+      }),
+    ).resolves.toEqual({ count: 0 })
     await expect(
       routes.getUnreadNotificationCount({
         actorDid: viewer,
@@ -692,6 +780,72 @@ describe('community post tenant discriminator', () => {
         allowedSpaceUris: [],
       }),
     ).resolves.toEqual({ count: 0 })
+  })
+
+  it('filters private rows before applying the standard notification limit', async () => {
+    const viewer = 'did:plc:notification-list-viewer'
+    const spaceUri = 'at://did:plc:tenant/space/community.blacksky.feed/private'
+    const privatePost = `${spaceUri}/did:plc:alice/app.bsky.feed.post/private`
+    const flaggedPost = `${spaceUri}/did:plc:alice/app.bsky.feed.post/flagged`
+    const publicPost = 'at://did:plc:alice/app.bsky.feed.post/public'
+    const now = Date.now()
+    await db.db
+      .insertInto('notification')
+      .values([
+        {
+          did: viewer,
+          recordUri: flaggedPost,
+          recordCid: 'bafyflagged',
+          author: 'did:plc:alice',
+          reason: 'mention',
+          reasonSubject: flaggedPost,
+          sortAt: new Date(now + 1_000).toISOString(),
+        },
+        {
+          did: viewer,
+          recordUri: privatePost,
+          recordCid: 'bafyprivate',
+          author: 'did:plc:alice',
+          reason: 'mention',
+          reasonSubject: privatePost,
+          sortAt: new Date(now).toISOString(),
+        },
+        {
+          did: viewer,
+          recordUri: publicPost,
+          recordCid: 'bafypublic',
+          author: 'did:plc:alice',
+          reason: 'mention',
+          reasonSubject: null,
+          sortAt: new Date(now - 1_000).toISOString(),
+        },
+      ])
+      .execute()
+    await insertPost(privatePost, spaceUri)
+    await insertPost(flaggedPost, spaceUri)
+    await db.db
+      .updateTable('community_post')
+      .set({ moderation_flagged_at: new Date(now).toISOString() })
+      .where('uri', '=', flaggedPost)
+      .execute()
+    const routes = notificationRoutes(db) as any
+
+    await expect(
+      routes.getNotifications({
+        actorDid: viewer,
+        limit: 1,
+        priority: false,
+        includeSpaceNotifications: false,
+      }),
+    ).resolves.toMatchObject({ notifications: [{ uri: publicPost }] })
+    await expect(
+      routes.getNotifications({
+        actorDid: viewer,
+        limit: 1,
+        priority: false,
+        includeSpaceNotifications: true,
+      }),
+    ).resolves.toMatchObject({ notifications: [{ uri: privatePost }] })
   })
 
   describe('moderation flags', () => {


### PR DESCRIPTION
## Summary

Keep the standard notification list and unread-count responses limited to public AT URIs, and add authenticated Blacksky queries that return the authorized union of public and private-space notifications. The new routes fail closed for malformed or mixed notification domains and preserve pagination and shared seen-state semantics.

## Test plan

- [ ] CI passes package codegen and TypeScript build
- [ ] CI passes notification contract, pagination, domain, and authorization tests
- [ ] CI passes data-plane PostgreSQL coverage for pre-limit filtering, unread counts, moderation, and shared seen state