### PR TITLE
feat(bsky): add hot sort to the community timeline

### DIFF
--- a/lexicons/community/blacksky/feed/getCommunityTimeline.json
+++ b/lexicons/community/blacksky/feed/getCommunityTimeline.json
@@ -16,6 +16,12 @@
           },
           "cursor": {
             "type": "string"
+          },
+          "sort": {
+            "type": "string",
+            "description": "recent: reverse-chronological. hot: engagement-ranked top-level posts from the last 7 days.",
+            "knownValues": ["recent", "hot"],
+            "default": "recent"
           }
         }
       },

--- a/packages/bsky/package.json
+++ b/packages/bsky/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atproto/bsky",
-  "version": "0.0.270",
+  "version": "0.0.271",
   "license": "MIT",
   "description": "Reference implementation of app.bsky App View (Bluesky API)",
   "keywords": [

--- a/packages/bsky/proto/bsky.proto
+++ b/packages/bsky/proto/bsky.proto
@@ -1882,6 +1882,7 @@ service Service {
   rpc GetCommunityPostQuotes(GetCommunityPostQuotesRequest) returns (GetCommunityPostQuotesResponse);
   rpc GetCommunityPostViewerLike(GetCommunityPostViewerLikeRequest) returns (GetCommunityPostViewerLikeResponse);
   rpc GetCommunityTimeline(GetCommunityTimelineRequest) returns (GetCommunityTimelineResponse);
+  rpc GetCommunityHotTimeline(GetCommunityTimelineRequest) returns (GetCommunityTimelineResponse);
   rpc RecordPeerModLabel(RecordPeerModLabelRequest) returns (RecordPeerModLabelResponse);
   rpc NegatePeerModLabel(NegatePeerModLabelRequest) returns (NegatePeerModLabelResponse);
   rpc GetPeerModLabelsForSubject(GetPeerModLabelsForSubjectRequest) returns (GetPeerModLabelsForSubjectResponse);

--- a/packages/bsky/src/api/community/blacksky/feed/getCommunityTimeline.ts
+++ b/packages/bsky/src/api/community/blacksky/feed/getCommunityTimeline.ts
@@ -32,10 +32,16 @@ export default function (server: Server, ctx: AppContext) {
         )
       }
       const limit = params.limit ?? 50
-      const res = await ctx.dataplane.getCommunityTimeline({
-        limit,
-        cursor: params.cursor,
-      })
+      const res =
+        params.sort === 'hot'
+          ? await ctx.dataplane.getCommunityHotTimeline({
+              limit,
+              cursor: params.cursor,
+            })
+          : await ctx.dataplane.getCommunityTimeline({
+              limit,
+              cursor: params.cursor,
+            })
       const labelers = ctx.reqLabelers(req)
       const hydrateCtx = await ctx.hydrator.createContext({
         labelers,

--- a/packages/bsky/src/data-plane/server/routes/community-hot.ts
+++ b/packages/bsky/src/data-plane/server/routes/community-hot.ts
@@ -1,0 +1,102 @@
+import type { ServiceImpl } from '@connectrpc/connect'
+import type { Service } from '../../../proto/bsky_connect.js'
+import type { Database } from '../db/index.js'
+import { communityPostFromRow } from './community-util.js'
+
+export const HOT_WINDOW_DAYS = 7
+export const HOT_GRAVITY = 1.8
+export const HOT_BASELINE = 0.3
+export const HOT_QUOTE_WEIGHT = 2
+export const HOT_REPLY_WEIGHT = 3
+
+const CURSOR_SEPARATOR = '::'
+
+export type HotCursor = {
+  anchor: string
+  score: string
+  cid: string
+}
+
+export const formatHotCursor = ({ anchor, score, cid }: HotCursor): string =>
+  [anchor, score, cid].join(CURSOR_SEPARATOR)
+
+export const parseHotCursor = (
+  cursor: string | undefined,
+): HotCursor | null => {
+  if (!cursor) return null
+  const parts = cursor.split(CURSOR_SEPARATOR)
+  if (parts.length !== 3) return null
+  const [anchor, score, cid] = parts
+  if (Number.isNaN(Date.parse(anchor))) return null
+  if (!/^\d+$/.test(score)) return null
+  if (!cid) return null
+  return { anchor, score, cid }
+}
+
+export const hotWindowStart = (anchor: string): string =>
+  new Date(
+    Date.parse(anchor) - HOT_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+  ).toISOString()
+
+// Score = (baseline + engagement) / (age_hours + 2) ^ gravity, the Hacker
+// News ranking. Everything is measured as of the anchor carried in the cursor
+// so that later pages rank against the same snapshot as the first one.
+const HOT_QUERY = `
+  WITH window_posts AS (
+    SELECT * FROM community_post
+    WHERE space_uri IS NULL AND moderation_flagged_at IS NULL
+      AND "sortAt" > $2::text AND "sortAt" <= $1::text
+  ), replies AS (
+    SELECT "replyParent" AS uri, count(*)::int AS n
+    FROM window_posts WHERE "replyParent" IS NOT NULL GROUP BY 1
+  ), quotes AS (
+    SELECT COALESCE(embed->'record'->>'uri', embed->'record'->'record'->>'uri') AS uri,
+           count(*)::int AS n
+    FROM window_posts WHERE embed IS NOT NULL GROUP BY 1
+  ), scored AS (
+    SELECT p.*,
+      round(1000000 * (${HOT_BASELINE} + COALESCE(pa."likeCount", 0)
+          + ${HOT_QUOTE_WEIGHT} * COALESCE(q.n, 0)
+          + ${HOT_REPLY_WEIGHT} * COALESCE(r.n, 0))
+        / power(EXTRACT(epoch FROM ($1::text::timestamptz - p."indexedAt"::timestamptz)) / 3600 + 2, ${HOT_GRAVITY}))::bigint AS score
+    FROM window_posts p
+    LEFT JOIN post_agg pa ON pa.uri = p.uri
+    LEFT JOIN replies r ON r.uri = p.uri
+    LEFT JOIN quotes q ON q.uri = p.uri
+    WHERE p."replyParent" IS NULL
+  )
+  SELECT * FROM scored
+  WHERE $3::bigint IS NULL OR score < $3::bigint OR (score = $3::bigint AND cid < $4::text)
+  ORDER BY score DESC, cid DESC
+  LIMIT $5
+`
+
+export default (db: Database): Partial<ServiceImpl<typeof Service>> => ({
+  async getCommunityHotTimeline(req) {
+    const { limit } = req
+    const cursor = parseHotCursor(req.cursor)
+    const anchor = cursor?.anchor ?? new Date().toISOString()
+    const res = await db.pool.query(HOT_QUERY, [
+      anchor,
+      hotWindowStart(anchor),
+      cursor?.score ?? null,
+      cursor?.cid ?? '',
+      limit + 1,
+    ])
+    const rows = res.rows
+    let nextCursor = ''
+    if (rows.length > limit) {
+      rows.pop()
+      const last = rows[rows.length - 1]
+      nextCursor = formatHotCursor({
+        anchor,
+        score: String(last.score),
+        cid: last.cid,
+      })
+    }
+    return {
+      posts: rows.map(communityPostFromRow),
+      cursor: nextCursor,
+    }
+  },
+})

--- a/packages/bsky/src/data-plane/server/routes/community-hot.ts
+++ b/packages/bsky/src/data-plane/server/routes/community-hot.ts
@@ -8,6 +8,8 @@ export const HOT_GRAVITY = 1.8
 export const HOT_BASELINE = 0.3
 export const HOT_QUOTE_WEIGHT = 2
 export const HOT_REPLY_WEIGHT = 3
+export const HOT_MIN_LIKES = 1
+export const HOT_MIN_INTERACTIONS = 2
 
 const CURSOR_SEPARATOR = '::'
 
@@ -40,7 +42,8 @@ export const hotWindowStart = (anchor: string): string =>
 
 // Score = (baseline + engagement) / (age_hours + 2) ^ gravity, the Hacker
 // News ranking. Everything is measured as of the anchor carried in the cursor
-// so that later pages rank against the same snapshot as the first one.
+// so that later pages rank against the same snapshot as the first one. Posts
+// under the like and interaction floors never rank, however fresh they are.
 const HOT_QUERY = `
   WITH window_posts AS (
     SELECT * FROM community_post
@@ -64,6 +67,8 @@ const HOT_QUERY = `
     LEFT JOIN replies r ON r.uri = p.uri
     LEFT JOIN quotes q ON q.uri = p.uri
     WHERE p."replyParent" IS NULL
+      AND COALESCE(pa."likeCount", 0) >= ${HOT_MIN_LIKES}
+      AND COALESCE(pa."likeCount", 0) + COALESCE(q.n, 0) + COALESCE(r.n, 0) >= ${HOT_MIN_INTERACTIONS}
   )
   SELECT * FROM scored
   WHERE $3::bigint IS NULL OR score < $3::bigint OR (score = $3::bigint AND cid < $4::text)

--- a/packages/bsky/src/data-plane/server/routes/index.ts
+++ b/packages/bsky/src/data-plane/server/routes/index.ts
@@ -7,6 +7,7 @@ import activitySubscription from './activity-subscription.js'
 import badge from './badge.js'
 import blocks from './blocks.js'
 import bookmarks from './bookmarks.js'
+import communityHot from './community-hot.js'
 import community from './community.js'
 import drafts from './drafts.js'
 import feedGens from './feed-gens.js'
@@ -45,6 +46,7 @@ export default (
       ...blocks(db),
       ...bookmarks(db),
       ...community(db, membershipPool),
+      ...communityHot(db),
       ...drafts(db),
       ...feedGens(db),
       ...feeds(db),

--- a/packages/bsky/tests/community/community-hot-timeline.test.ts
+++ b/packages/bsky/tests/community/community-hot-timeline.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from 'vitest'
+import getCommunityTimelineRoute from '../../src/api/community/blacksky/feed/getCommunityTimeline.js'
+import communityHot, {
+  HOT_WINDOW_DAYS,
+  formatHotCursor,
+  hotWindowStart,
+  parseHotCursor,
+} from '../../src/data-plane/server/routes/community-hot.js'
+
+const VIEWER = 'did:plc:viewer'
+const ANCHOR = '2026-09-03T12:00:00.000Z'
+const CID = 'bafyreiacsg6vsw7ppwbnowzsdgstulhrwftirtcnvkcbnfgvhwjrnzfmsu'
+
+describe('hot cursor', () => {
+  it('round-trips through format and parse', () => {
+    const cursor = { anchor: ANCHOR, score: '12345', cid: CID }
+    expect(parseHotCursor(formatHotCursor(cursor))).toEqual(cursor)
+  })
+
+  it('treats a missing or malformed cursor as the first page', () => {
+    expect(parseHotCursor(undefined)).toBeNull()
+    expect(parseHotCursor('')).toBeNull()
+    expect(parseHotCursor(ANCHOR)).toBeNull()
+    expect(parseHotCursor(`not-a-date::1::${CID}`)).toBeNull()
+    expect(parseHotCursor(`${ANCHOR}::1.5::${CID}`)).toBeNull()
+    expect(parseHotCursor(`${ANCHOR}::-1::${CID}`)).toBeNull()
+    expect(parseHotCursor(`${ANCHOR}::1::`)).toBeNull()
+    expect(parseHotCursor(`${ANCHOR}::1::${CID}::extra`)).toBeNull()
+  })
+
+  it('opens the window a fixed number of days before the anchor', () => {
+    const start = hotWindowStart(ANCHOR)
+    expect(Date.parse(ANCHOR) - Date.parse(start)).toBe(
+      HOT_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+    )
+    expect(start < ANCHOR).toBe(true)
+  })
+})
+
+describe('getCommunityHotTimeline dataplane route', () => {
+  const row = (cid: string, score: number) => ({
+    uri: `at://did:plc:alice/community.blacksky.feed.post/${cid}`,
+    cid,
+    creator: 'did:plc:alice',
+    text: 'hot',
+    createdAt: ANCHOR,
+    indexedAt: ANCHOR,
+    sortAt: ANCHOR,
+    score: String(score),
+  })
+
+  const makeDb = (rows: unknown[]) => {
+    const query = vi.fn(async () => ({ rows: [...rows] }))
+    return { db: { pool: { query } } as any, query }
+  }
+
+  it('anchors the first page at now and passes an open cursor', async () => {
+    const { db, query } = makeDb([row('a', 3), row('b', 2)])
+    const before = Date.now()
+    const res = await (communityHot(db) as any).getCommunityHotTimeline({
+      limit: 30,
+      cursor: '',
+    })
+
+    const [, params] = query.mock.calls[0] as unknown as [string, unknown[]]
+    const anchor = params[0] as string
+    expect(Date.parse(anchor)).toBeGreaterThanOrEqual(before)
+    expect(params[1]).toBe(hotWindowStart(anchor))
+    expect(params[2]).toBeNull()
+    expect(params[3]).toBe('')
+    expect(params[4]).toBe(31)
+    expect(res.posts.map((p: any) => p.cid)).toEqual(['a', 'b'])
+    expect(res.cursor).toBe('')
+  })
+
+  it('keeps the anchor from the cursor and continues after the last row', async () => {
+    const { db, query } = makeDb([row('c', 9), row('b', 8), row('a', 7)])
+    const cursor = formatHotCursor({ anchor: ANCHOR, score: '10', cid: 'd' })
+    const res = await (communityHot(db) as any).getCommunityHotTimeline({
+      limit: 2,
+      cursor,
+    })
+
+    const [, params] = query.mock.calls[0] as unknown as [string, unknown[]]
+    expect(params[0]).toBe(ANCHOR)
+    expect(params[2]).toBe('10')
+    expect(params[3]).toBe('d')
+    expect(params[4]).toBe(3)
+    expect(res.posts.map((p: any) => p.cid)).toEqual(['c', 'b'])
+    expect(res.cursor).toBe(
+      formatHotCursor({ anchor: ANCHOR, score: '8', cid: 'b' }),
+    )
+  })
+})
+
+describe('getCommunityTimeline sort param', () => {
+  const makeCtx = () => ({
+    reqLabelers: () => ({ dids: [], redact: new Set<string>() }),
+    hydrator: { createContext: async (v: any) => v },
+    views: {},
+    dataplane: {
+      checkCommunityMembership: vi.fn(async () => ({ isMember: true })),
+      getCommunityTimeline: vi.fn(async () => ({
+        posts: [],
+        cursor: 'recent-cursor',
+      })),
+      getCommunityHotTimeline: vi.fn(async () => ({
+        posts: [],
+        cursor: 'hot-cursor',
+      })),
+    },
+    authVerifier: { standard: {} },
+  })
+
+  const registerHandler = (ctx: any) => {
+    let captured: any
+    getCommunityTimelineRoute(
+      { add: (_lex: unknown, cfg: any) => (captured = cfg) } as any,
+      ctx,
+    )
+    return (params: any) =>
+      captured.handler({
+        params,
+        auth: { credentials: { iss: VIEWER } },
+        req: { headers: {} },
+      })
+  }
+
+  it('serves the chronological timeline by default', async () => {
+    const ctx = makeCtx()
+    const res = await registerHandler(ctx)({ limit: 30, cursor: 'c1' })
+
+    expect(ctx.dataplane.getCommunityTimeline).toHaveBeenCalledWith({
+      limit: 30,
+      cursor: 'c1',
+    })
+    expect(ctx.dataplane.getCommunityHotTimeline).not.toHaveBeenCalled()
+    expect(res.body.cursor).toBe('recent-cursor')
+  })
+
+  it('treats an explicit recent sort like the default', async () => {
+    const ctx = makeCtx()
+    await registerHandler(ctx)({ limit: 30, sort: 'recent' })
+
+    expect(ctx.dataplane.getCommunityTimeline).toHaveBeenCalledTimes(1)
+    expect(ctx.dataplane.getCommunityHotTimeline).not.toHaveBeenCalled()
+  })
+
+  it('routes the hot sort to the ranked timeline with its cursor', async () => {
+    const ctx = makeCtx()
+    const res = await registerHandler(ctx)({
+      limit: 30,
+      sort: 'hot',
+      cursor: 'h1',
+    })
+
+    expect(ctx.dataplane.getCommunityHotTimeline).toHaveBeenCalledWith({
+      limit: 30,
+      cursor: 'h1',
+    })
+    expect(ctx.dataplane.getCommunityTimeline).not.toHaveBeenCalled()
+    expect(res.body.cursor).toBe('hot-cursor')
+  })
+})


### PR DESCRIPTION
Adds an optional `sort=hot` param to `community.blacksky.feed.getCommunityTimeline`, served by a new `GetCommunityHotTimeline` dataplane RPC. Hot ranks public top-level community posts from the last 7 days by a Hacker News gravity score (likes, quotes, replies), requires at least one like and two interactions, and paginates on a snapshot cursor. Client side in blacksky-algorithms/blacksky.community#184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xo1ds3imzYASF5REohKWq