### PR TITLE
fix(bsky): preserve via-repost notification filters

### DIFF
--- a/.changeset/via-repost-notification-filters.md
+++ b/.changeset/via-repost-notification-filters.md
@@ -1,0 +1,5 @@
+---
+'@atproto/bsky': patch
+---
+
+Keep like and repost notifications generated through reposts independently configurable in notification lists.

--- a/packages/bsky/package.json
+++ b/packages/bsky/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atproto/bsky",
-  "version": "0.0.270",
+  "version": "0.0.271",
   "license": "MIT",
   "description": "Reference implementation of app.bsky App View (Bluesky API)",
   "keywords": [

--- a/packages/bsky/package.json
+++ b/packages/bsky/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atproto/bsky",
-  "version": "0.0.271",
+  "version": "0.0.270",
   "license": "MIT",
   "description": "Reference implementation of app.bsky App View (Bluesky API)",
   "keywords": [

--- a/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
+++ b/packages/bsky/src/api/app/bsky/notification/listNotifications.ts
@@ -25,7 +25,7 @@ import { resHeaders } from '../../../util.js'
 import { classifyNotificationDomain } from './domain.js'
 import { protobufToLex } from './util.js'
 
-const ALL_NOTIFICATION_REASONS_COUNT = 10
+const ALL_NOTIFICATION_REASONS_COUNT = 12
 const AUTHORIZED_UNION_SCAN_CAP = 1_000
 const NOTIFICATION_BATCH_SIZE = 100
 
@@ -47,8 +47,10 @@ const getPreferenceFilters = async (
     if (res.preferences.length !== 1) return { followsOnlyReasons: new Set() }
     const prefs = protobufToLex(res.preferences[0])
     const enabled: string[] = []
-    if (prefs.like.list || prefs.likeViaRepost.list) enabled.push('like')
-    if (prefs.repost.list || prefs.repostViaRepost.list) enabled.push('repost')
+    if (prefs.like.list) enabled.push('like')
+    if (prefs.likeViaRepost.list) enabled.push('like-via-repost')
+    if (prefs.repost.list) enabled.push('repost')
+    if (prefs.repostViaRepost.list) enabled.push('repost-via-repost')
     if (prefs.follow.list) enabled.push('follow')
     if (prefs.reply.list) enabled.push('reply')
     if (prefs.quote.list) enabled.push('quote')

--- a/packages/bsky/tests/views/notifications.test.ts
+++ b/packages/bsky/tests/views/notifications.test.ts
@@ -1070,6 +1070,125 @@ describe('notification views', () => {
       push: true,
     }
 
+    const createReasonFixtures = async () => {
+      const directSubject = (await sc.post(carol, 'preference direct subject'))
+        .ref
+      const directLike = await sc.like(alice, directSubject)
+      const directRepost = await sc.repost(alice, directSubject)
+
+      const viaSubject = (await sc.post(dan, 'preference via subject')).ref
+      const viewerRepost = await sc.repost(carol, viaSubject)
+      const likeViaRepost = await sc.like(alice, viaSubject, {
+        via: viewerRepost.raw,
+      })
+      const repostViaRepost = await sc.repost(alice, viaSubject, {
+        via: viewerRepost.raw,
+      })
+      await network.processAll()
+
+      return {
+        directLike: directLike.toString(),
+        directRepost: directRepost.uriStr,
+        likeViaRepost: likeViaRepost.toString(),
+        repostViaRepost: repostViaRepost.uriStr,
+      }
+    }
+
+    const filterPreference = (
+      list: boolean,
+    ): AppBskyNotificationDefs.FilterablePreference => ({
+      include: 'all',
+      list,
+      push: true,
+    })
+
+    const putPreferences = async (
+      preferences: AppBskyNotificationPutPreferencesV2.InputSchema,
+    ) => {
+      await agent.app.bsky.notification.putPreferencesV2(preferences, {
+        encoding: 'application/json',
+        headers: await network.serviceHeaders(
+          carol,
+          ids.AppBskyNotificationPutPreferencesV2,
+        ),
+      })
+      await network.processAll()
+    }
+
+    const listCarolNotifications = async () => {
+      const response = await agent.app.bsky.notification.listNotifications(
+        { priority: false },
+        {
+          headers: await network.serviceHeaders(
+            carol,
+            ids.AppBskyNotificationListNotifications,
+          ),
+        },
+      )
+      return response.data.notifications
+    }
+
+    it('keeps repost-via-repost notifications with mixed list preferences', async () => {
+      const fixtures = await createReasonFixtures()
+      await putPreferences({
+        like: filterPreference(false),
+        likeViaRepost: filterPreference(false),
+        repost: filterPreference(true),
+        repostViaRepost: filterPreference(true),
+      })
+
+      const notifications = await listCarolNotifications()
+      expect(
+        notifications.some(
+          (notification) =>
+            notification.uri === fixtures.directLike ||
+            notification.uri === fixtures.likeViaRepost,
+        ),
+      ).toBe(false)
+      expect(
+        notifications.find(
+          (notification) => notification.uri === fixtures.directRepost,
+        )?.reason,
+      ).toBe('repost')
+      expect(
+        notifications.find(
+          (notification) => notification.uri === fixtures.repostViaRepost,
+        )?.reason,
+      ).toBe('repost-via-repost')
+    })
+
+    it('applies list preferences independently to each like and repost reason', async () => {
+      const fixtures = await createReasonFixtures()
+      await putPreferences({
+        like: filterPreference(true),
+        likeViaRepost: filterPreference(false),
+        repost: filterPreference(false),
+        repostViaRepost: filterPreference(true),
+      })
+
+      const notifications = await listCarolNotifications()
+      expect(
+        notifications.find(
+          (notification) => notification.uri === fixtures.directLike,
+        )?.reason,
+      ).toBe('like')
+      expect(
+        notifications.some(
+          (notification) => notification.uri === fixtures.likeViaRepost,
+        ),
+      ).toBe(false)
+      expect(
+        notifications.some(
+          (notification) => notification.uri === fixtures.directRepost,
+        ),
+      ).toBe(false)
+      expect(
+        notifications.find(
+          (notification) => notification.uri === fixtures.repostViaRepost,
+        )?.reason,
+      ).toBe('repost-via-repost')
+    })
+
     it('gets preferences filling up with the defaults', async () => {
       const actorDid = sc.dids.carol
 


### PR DESCRIPTION
Notification list preferences now filter like, like-via-repost, repost, and repost-via-repost independently so enabled via-repost notifications remain visible. Adds regression coverage for mixed and independent list settings.

Test plan:
- [ ] Run the Bsky notification view suite through the package test wrapper
- [ ] Verify direct and via-repost reasons honor their individual list settings